### PR TITLE
feat: text field unit

### DIFF
--- a/.changeset/plenty-chairs-sip.md
+++ b/.changeset/plenty-chairs-sip.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-components": patch
+---
+
+Made input field visually indicate its focus state

--- a/.changeset/slimy-bananas-warn.md
+++ b/.changeset/slimy-bananas-warn.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-components": patch
+---
+
+Added unit prop to TextField component

--- a/apps/chronicles/screens/components/TextFieldScreen.tsx
+++ b/apps/chronicles/screens/components/TextFieldScreen.tsx
@@ -9,11 +9,16 @@ export const TextFieldScreen = () => {
     >
         <View style={styles.container}>
             <Typography>
-                You can use a TextField to accept user input
+                TextField acts as a convenience wrapper for the Input component.
             </Typography>
             <Spacer />
             <TextField label="Say something" placeholder="Anything goes here" />
-
+            <Spacer />
+            <Typography>
+                You may add units to it:
+            </Typography>
+            <Spacer />
+            <TextField label="Measurement" placeholder="Length" unit="(mm)" />
             <Spacer />
             <Typography>
                 It can accept multiple lines of text too

--- a/packages/components/src/components/Input/Input.tsx
+++ b/packages/components/src/components/Input/Input.tsx
@@ -79,7 +79,6 @@ const themedStyles = EDSStyleSheet.create((theme, props: { multiline: boolean, i
         contentContainer: {
             flexDirection: "row",
             backgroundColor: theme.colors.container.background,
-            paddingHorizontal: theme.spacing.textField.paddingHorizontal,
             ...borderStyle,
         },
         label: {
@@ -88,6 +87,7 @@ const themedStyles = EDSStyleSheet.create((theme, props: { multiline: boolean, i
         textInput: {
             paddingTop: theme.spacing.textField.paddingVertical,
             paddingBottom: theme.spacing.textField.paddingVertical,
+            paddingHorizontal: theme.spacing.textField.paddingHorizontal,
             color: theme.colors.text.primary,
             ...theme.typography.basic.input,
             minHeight: multiline ? 80 : undefined

--- a/packages/components/src/components/Input/Input.tsx
+++ b/packages/components/src/components/Input/Input.tsx
@@ -1,5 +1,5 @@
-import { TextInput, TextInputProps, View } from "react-native";
-import { ReactNode } from "react";
+import { TextInput, TextInputProps, View, ViewStyle } from "react-native";
+import { ReactNode, useState } from "react";
 import { EDSStyleSheet } from "../../styling";
 import { Label, useStyles } from "../..";
 import React from "react";
@@ -28,7 +28,8 @@ export const Input = React.forwardRef<TextInput, InputProps>(({
     disabled = false,
     ...rest
 }, ref) => {
-    const styles = useStyles(themedStyles, { multiline });
+    const [isSelected, setIsSelected] = useState<boolean>(false);
+    const styles = useStyles(themedStyles, { multiline, isSelected });
     return (
         <>
             {label && <Label style={styles.label} label={label} />}
@@ -45,6 +46,8 @@ export const Input = React.forwardRef<TextInput, InputProps>(({
                         onChangeText={onChange}
                         textAlignVertical="top"
                         placeholderTextColor={styles.placeholder.color}
+                        onFocus={() => setIsSelected(true)}
+                        onBlur={() => setIsSelected(false)}
                         style={[
                             styles.textInput,
                             rest.style
@@ -60,13 +63,23 @@ export const Input = React.forwardRef<TextInput, InputProps>(({
 
 Input.displayName = "Input";
 
-const themedStyles = EDSStyleSheet.create((theme, props: { multiline: boolean }) => {
+const themedStyles = EDSStyleSheet.create((theme, props: { multiline: boolean, isSelected: boolean }) => {
+    const { multiline, isSelected } = props;
+
+    let borderStyle: ViewStyle;
+    if (isSelected) borderStyle = {
+        borderColor: theme.colors.interactive.primary,
+        borderWidth: theme.geometry.border.focusedBorderWidth,
+    }
+    else borderStyle = {
+        borderColor: theme.colors.text.tertiary,
+        borderBottomWidth: theme.geometry.border.borderWidth,
+    }
     return {
         contentContainer: {
             flexDirection: "row",
             backgroundColor: theme.colors.container.background,
-            borderBottomWidth: theme.geometry.border.borderWidth,
-            borderBottomColor: theme.colors.border.medium,
+            ...borderStyle,
         },
         label: {
             paddingHorizontal: theme.spacing.textField.paddingHorizontal,
@@ -77,7 +90,7 @@ const themedStyles = EDSStyleSheet.create((theme, props: { multiline: boolean })
             paddingHorizontal: theme.spacing.textField.paddingHorizontal,
             color: theme.colors.text.primary,
             ...theme.typography.basic.input,
-            minHeight: props.multiline ? 80 : undefined
+            minHeight: multiline ? 80 : undefined
         },
         placeholder: {
             color: theme.colors.text.tertiary,

--- a/packages/components/src/components/Input/Input.tsx
+++ b/packages/components/src/components/Input/Input.tsx
@@ -79,6 +79,7 @@ const themedStyles = EDSStyleSheet.create((theme, props: { multiline: boolean, i
         contentContainer: {
             flexDirection: "row",
             backgroundColor: theme.colors.container.background,
+            paddingHorizontal: theme.spacing.textField.paddingHorizontal,
             ...borderStyle,
         },
         label: {
@@ -87,7 +88,6 @@ const themedStyles = EDSStyleSheet.create((theme, props: { multiline: boolean, i
         textInput: {
             paddingTop: theme.spacing.textField.paddingVertical,
             paddingBottom: theme.spacing.textField.paddingVertical,
-            paddingHorizontal: theme.spacing.textField.paddingHorizontal,
             color: theme.colors.text.primary,
             ...theme.typography.basic.input,
             minHeight: multiline ? 80 : undefined

--- a/packages/components/src/components/TextField/TextField.tsx
+++ b/packages/components/src/components/TextField/TextField.tsx
@@ -38,6 +38,6 @@ TextField.displayName = "TextField";
 const themeStyles = EDSStyleSheet.create(theme => ({
     unit: {
         justifyContent: "center",
-        paddingLeft: theme.spacing.textField.paddingHorizontal,
+        paddingHorizontal: theme.spacing.textField.paddingHorizontal,
     }
 }));

--- a/packages/components/src/components/TextField/TextField.tsx
+++ b/packages/components/src/components/TextField/TextField.tsx
@@ -1,22 +1,43 @@
 
-import { TextInput } from "react-native";
+import { TextInput, View } from "react-native";
 import { Input, InputProps } from "../Input";
 import React from "react";
+import { Typography } from "../Typography";
+import { EDSStyleSheet } from "../../styling";
+import { useStyles } from "../../hooks/useStyles";
 
-export type TextFieldProps = Omit<InputProps, "leftAdornment" | "rightAdornment">
+export type TextFieldProps = {
+    unit?: string;
+} & Omit<InputProps, "leftAdornment" | "rightAdornment">
 
 export const TextField = React.forwardRef<TextInput, TextFieldProps>(
     (
-        props,
+        {
+            unit,
+            ...rest
+        },
         ref
     ) => {
+        const styles = useStyles(themeStyles);
         return (
             <Input
                 ref={ref}
-                {...props}
+                rightAdornments={unit && (
+                    <View style={styles.unit}>
+                        <Typography variant="label" color="textTertiary">{unit}</Typography>
+                    </View>
+                )}
+                {...rest}
             />
         );
     }
 );
 
 TextField.displayName = "TextField";
+
+const themeStyles = EDSStyleSheet.create(theme => ({
+    unit: {
+        justifyContent: "center",
+        paddingLeft: theme.spacing.textField.paddingHorizontal,
+    }
+}));

--- a/packages/components/src/styling/masterToken.ts
+++ b/packages/components/src/styling/masterToken.ts
@@ -133,6 +133,7 @@ export const masterToken: MasterToken = {
             elementBorderRadius: 4,
             containerBorderRadius: 24,
             borderWidth: 1,
+            focusedBorderWidth: 2,
         },
         dimension: {
             button: {

--- a/packages/components/src/styling/types.ts
+++ b/packages/components/src/styling/types.ts
@@ -89,6 +89,7 @@ export type MasterToken = {
             elementBorderRadius: number;
             containerBorderRadius: number;
             borderWidth: number;
+            focusedBorderWidth: number;
         };
         dimension: {
             button: {


### PR DESCRIPTION
- Adjust `Input` bottom border color
- Visually indicate focus state of `Input`
- Add `unit` prop to `TextField`