### PR TITLE
docs(repo): add code snippet placeholder text in issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-form.yml
+++ b/.github/ISSUE_TEMPLATE/bug-form.yml
@@ -48,7 +48,7 @@ body:
     attributes:
       label: Other info
       description: Please provide any additional details should you have some
-      placeholder: Details, context, code snippts etc...
+      placeholder: Details, context, code snippets etc...
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/bug-form.yml
+++ b/.github/ISSUE_TEMPLATE/bug-form.yml
@@ -1,6 +1,6 @@
 name: 🐛 Bug Report
 description: File a bug report
-title: ""
+title: "[TITLE]"
 labels: ["bug"]
 
 body:

--- a/.github/ISSUE_TEMPLATE/bug-form.yml
+++ b/.github/ISSUE_TEMPLATE/bug-form.yml
@@ -1,6 +1,6 @@
 name: 🐛 Bug Report
 description: File a bug report
-title: "[Bug]: "
+title: ""
 labels: ["bug"]
 
 body:
@@ -48,7 +48,7 @@ body:
     attributes:
       label: Other info
       description: Please provide any additional details should you have some
-      placeholder: Details, context, etc...
+      placeholder: Details, context, code snippts etc...
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/feature-form.yml
+++ b/.github/ISSUE_TEMPLATE/feature-form.yml
@@ -48,6 +48,6 @@ body:
     attributes:
       label: Other info
       description: Please provide any additional details should you have some
-      placeholder: Details, context, etc...
+      placeholder: Details, context, code snippets etc...
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature-form.yml
+++ b/.github/ISSUE_TEMPLATE/feature-form.yml
@@ -1,6 +1,6 @@
 name: 🆕 Feature request
 description: Request new features to be added to the platform
-title: "[Feature]: "
+title: "[TITLE]"
 labels: ["feature"]
 
 body:


### PR DESCRIPTION
- Replace old form titles with `[TITLE]` (the user has to delete this as GitHub does not allow for emtpy titles in forms)
- Add "code snippets" to "Other" sections of the forms


closes #156 