### PR TITLE
fix: navigation package dependency issues

### DIFF
--- a/.changeset/dry-seahorses-clap.md
+++ b/.changeset/dry-seahorses-clap.md
@@ -1,0 +1,6 @@
+---
+"@equinor/mad-navigation": patch
+---
+
+The package now exports the `EnvironmentProvider` component for setting the navigation environment
+banner.

--- a/apps/chronicles/navigation/index.tsx
+++ b/apps/chronicles/navigation/index.tsx
@@ -4,7 +4,11 @@
  *
  */
 import React from "react";
-import { createBottomTabNavigator, createNativeStackNavigator } from "@equinor/mad-navigation";
+import {
+    createBottomTabNavigator,
+    createNativeStackNavigator,
+    EnvironmentProvider,
+} from "@equinor/mad-navigation";
 import { NavigationContainer } from "@react-navigation/native";
 import { ColorSchemeName } from "react-native";
 
@@ -18,7 +22,7 @@ import { SignatureScreen } from "../screens/SignatureTest";
 import { PaperScreen } from "../screens/components/PaperScreen";
 import { PopoverScreen } from "../screens/components/PopoverScreen";
 import { ButtonScreen } from "../screens/components/ButtonScreen";
-import { Color, EnvironmentProvider, Icon, IconName, useToken } from "@equinor/mad-components";
+import { Color, Icon, IconName, useToken } from "@equinor/mad-components";
 import { InputScreen } from "../screens/components/InputScreen";
 import { TextFieldScreen } from "../screens/components/TextFieldScreen";
 import { SearchScreen } from "../screens/components/SearchScreen";

--- a/apps/chronicles/package.json
+++ b/apps/chronicles/package.json
@@ -11,7 +11,8 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@equinor/mad-components": "*",
+    "@equinor/mad-components": "workspace:*",
+    "@equinor/mad-navigation": "workspace:*",
     "@equinor/react-native-skia-draw": "workspace:*",
     "@expo/vector-icons": "^13.0.0",
     "@expo/webpack-config": "^18.0.1",

--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -25,11 +25,13 @@
     "homepage": "https://github.com/equinor/mad/",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
+    "dependencies": {
+        "@equinor/mad-components": "workspace:*"
+    },
     "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8",
         "react-native": ">=0.68",
-        "@equinor/mad-components": "workspace:*",
         "@react-navigation/native": ">=6",
         "@react-navigation/native-stack": ">=6",
         "@react-navigation/bottom-tabs": ">=6"

--- a/packages/navigation/src/index.ts
+++ b/packages/navigation/src/index.ts
@@ -1,2 +1,3 @@
-export * from './bottom-tab'
-export * from './native-stack'
+export * from "./bottom-tab";
+export * from "./native-stack";
+export { EnvironmentProvider } from "@equinor/mad-components";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
       eslint: 8.48.0
       jest: 29.6.4_dxriesx7donpxdng6xmr42kubu
       prettier: 3.0.1
-      ts-jest: 29.1.1_csrhwi5xvc6uasz2wtwewilb5m
+      ts-jest: 29.1.1_viekctkmyg3fwkrpb5gzerjumy
       ts-node: 10.9.1_moxb6vrpjkxc46e5r7c2uupsoe
       tsconfig: link:packages/tsconfig
       tslib: 2.6.2
@@ -38,7 +38,8 @@ importers:
     specifiers:
       '@babel/core': ^7.21.4
       '@equinor/eslint-config-mad': workspace:*
-      '@equinor/mad-components': '*'
+      '@equinor/mad-components': workspace:*
+      '@equinor/mad-navigation': workspace:*
       '@equinor/react-native-skia-draw': workspace:*
       '@expo/vector-icons': ^13.0.0
       '@expo/webpack-config': ^18.0.1
@@ -73,6 +74,7 @@ importers:
       uuid: ^3.0.0
     dependencies:
       '@equinor/mad-components': link:../../packages/components
+      '@equinor/mad-navigation': link:../../packages/navigation
       '@equinor/react-native-skia-draw': link:../../packages/skia-draw
       '@expo/vector-icons': 13.0.0
       '@expo/webpack-config': 18.1.2_expo@49.0.8
@@ -86,15 +88,15 @@ importers:
       expo-font: 11.4.0_expo@49.0.8
       expo-image-picker: 14.3.2_expo@49.0.8
       expo-linking: 5.0.2_expo@49.0.8
-      expo-splash-screen: 0.20.5_5pnih3po4zk6kucbfu7de2bahi
+      expo-splash-screen: 0.20.5_expo@49.0.8
       expo-status-bar: 1.6.0
       expo-system-ui: 2.4.0_expo@49.0.8
       expo-web-browser: 12.3.2_expo@49.0.8
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-native: 0.72.3_h5dl4kw4qyl3ku2pqfjzys6che
+      react-native: 0.72.3_dyjrdn4cwwk5zc2yxh6dginkjq
       react-native-gesture-handler: 2.12.1_6syixf76bqx5r4tgwtwyqyssoi
-      react-native-reanimated: 3.3.0_rbcj43ea2zki67y63rdmpi5f5e
+      react-native-reanimated: 3.3.0_c45zjcyxv4v5qicydpgeee2qeq
       react-native-safe-area-context: 4.6.3_6syixf76bqx5r4tgwtwyqyssoi
       react-native-screens: 3.22.1_6syixf76bqx5r4tgwtwyqyssoi
       react-native-svg: 13.9.0_6syixf76bqx5r4tgwtwyqyssoi
@@ -105,7 +107,7 @@ importers:
       '@equinor/eslint-config-mad': link:../../packages/eslint-config-mad
       '@types/react': 18.2.21
       '@types/react-native': 0.70.14
-      babel-loader: 8.3.0_7nqnrdwtl44yxbgqpombxtkqjy
+      babel-loader: 8.3.0_@babel+core@7.22.11
       react-test-renderer: 18.1.0_react@18.2.0
       typescript: 5.2.2
 
@@ -124,22 +126,8 @@ importers:
     specifiers:
       '@equinor/eslint-config-mad': workspace:*
       '@floating-ui/react-native': ^0.10.0
-      expo-font: '>=10.0.0'
-      react: '>=16.8'
-      react-dom: '>=16.8'
-      react-native: '>=0.68'
-      react-native-gesture-handler: '>=2.0'
-      react-native-reanimated: '>=2.0'
-      react-native-svg: '>=13.0'
     dependencies:
-      '@floating-ui/react-native': 0.10.1_6syixf76bqx5r4tgwtwyqyssoi
-      expo-font: 11.4.0_expo@49.0.8
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      react-native: 0.72.3_h5dl4kw4qyl3ku2pqfjzys6che
-      react-native-gesture-handler: 2.12.1_6syixf76bqx5r4tgwtwyqyssoi
-      react-native-reanimated: 3.3.0_rbcj43ea2zki67y63rdmpi5f5e
-      react-native-svg: 13.9.0_6syixf76bqx5r4tgwtwyqyssoi
+      '@floating-ui/react-native': 0.10.1
     devDependencies:
       '@equinor/eslint-config-mad': link:../eslint-config-mad
 
@@ -147,7 +135,6 @@ importers:
     specifiers:
       '@typescript-eslint/eslint-plugin': ^5.21.0
       '@typescript-eslint/parser': ^5.21.0
-      eslint: ^8
       eslint-config-prettier: ^9.0.0
       eslint-import-resolver-typescript: ^3.6.0
       eslint-plugin-eslint-comments: ^3.2.0
@@ -156,35 +143,22 @@ importers:
       eslint-plugin-react-hooks: ^4.6.0
       eslint-plugin-simple-import-sort: ^10.0.0
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0_pv3pg3japumrjsd4wswxrcr33u
-      '@typescript-eslint/parser': 5.62.0_w2g2uv42be7wag4oipwkfv43p4
-      eslint: 8.48.0
-      eslint-config-prettier: 9.0.0_eslint@8.48.0
-      eslint-import-resolver-typescript: 3.6.0_rksubgp4nk5ffepfua3qexp6q4
-      eslint-plugin-eslint-comments: 3.2.0_eslint@8.48.0
-      eslint-plugin-import: 2.28.1_op7bh4tdgs2eg2llb7ukqwpcza
-      eslint-plugin-react: 7.32.2_eslint@8.48.0
-      eslint-plugin-react-hooks: 4.6.0_eslint@8.48.0
-      eslint-plugin-simple-import-sort: 10.0.0_eslint@8.48.0
+      '@typescript-eslint/eslint-plugin': 5.62.0_ymvan467kgsinhigrcqohgvliu
+      '@typescript-eslint/parser': 5.62.0
+      eslint-config-prettier: 9.0.0
+      eslint-import-resolver-typescript: 3.6.0_57gzdhhtk7qjbqqkq5tdmx2zhu
+      eslint-plugin-eslint-comments: 3.2.0
+      eslint-plugin-import: 2.28.1_tuirrgthw55etjceyndomyqnfa
+      eslint-plugin-react: 7.32.2
+      eslint-plugin-react-hooks: 4.6.0
+      eslint-plugin-simple-import-sort: 10.0.0
 
   packages/navigation:
     specifiers:
       '@equinor/eslint-config-mad': workspace:*
       '@equinor/mad-components': workspace:*
-      '@react-navigation/bottom-tabs': '>=6'
-      '@react-navigation/native': '>=6'
-      '@react-navigation/native-stack': '>=6'
-      react: '>=16.8'
-      react-dom: '>=16.8'
-      react-native: '>=0.68'
     dependencies:
       '@equinor/mad-components': link:../components
-      '@react-navigation/bottom-tabs': 6.5.8_yu75tq5j2brzsa2nme6433wuti
-      '@react-navigation/native': 6.1.7_6syixf76bqx5r4tgwtwyqyssoi
-      '@react-navigation/native-stack': 6.9.13_yu75tq5j2brzsa2nme6433wuti
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      react-native: 0.72.3_h5dl4kw4qyl3ku2pqfjzys6che
     devDependencies:
       '@equinor/eslint-config-mad': link:../eslint-config-mad
 
@@ -192,14 +166,8 @@ importers:
     specifiers:
       '@equinor/eslint-config-mad': workspace:*
       '@equinor/mad-components': workspace:*
-      '@shopify/react-native-skia': ^0.1.141
-      react: '>=18.0'
-      react-native: '>=0.64'
     dependencies:
       '@equinor/mad-components': link:../components
-      '@shopify/react-native-skia': 0.1.196_6syixf76bqx5r4tgwtwyqyssoi
-      react: 18.2.0
-      react-native: 0.72.3_h5dl4kw4qyl3ku2pqfjzys6che
     devDependencies:
       '@equinor/eslint-config-mad': link:../eslint-config-mad
 
@@ -211,6 +179,7 @@ packages:
   /@aashutoshrathi/word-wrap/1.2.6:
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /@ampproject/remapping/2.2.1:
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
@@ -2065,6 +2034,15 @@ packages:
     dev: true
     optional: true
 
+  /@eslint-community/eslint-utils/4.4.0:
+    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+    dependencies:
+      eslint-visitor-keys: 3.4.3
+    dev: false
+
   /@eslint-community/eslint-utils/4.4.0_eslint@8.48.0:
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2073,6 +2051,7 @@ packages:
     dependencies:
       eslint: 8.48.0
       eslint-visitor-keys: 3.4.3
+    dev: true
 
   /@eslint-community/regexpp/4.8.0:
     resolution: {integrity: sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==}
@@ -2093,10 +2072,12 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@eslint/js/8.48.0:
     resolution: {integrity: sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
 
   /@expo/bunyan/4.0.0:
     resolution: {integrity: sha512-Ydf4LidRB/EBI+YrB+cVLqIseiRfjUI/AeHBgjGMtq3GroraDu81OV7zqophRgupngoL3iS3JUMDMnxO7g39qA==}
@@ -2385,6 +2366,26 @@ packages:
       xmlbuilder: 14.0.0
     dev: false
 
+  /@expo/prebuild-config/6.2.6:
+    resolution: {integrity: sha512-uFVvDAm9dPg9p1qpnr4CVnpo2hmkZIL5FQz+VlIdXXJpe7ySh/qTGHtKWY/lWUshQkAJ0nwbKGPztGWdABns/Q==}
+    peerDependencies:
+      expo-modules-autolinking: '>=0.8.1'
+    dependencies:
+      '@expo/config': 8.1.2
+      '@expo/config-plugins': 7.2.5
+      '@expo/config-types': 49.0.0
+      '@expo/image-utils': 0.3.22
+      '@expo/json-file': 8.2.37
+      debug: 4.3.4
+      fs-extra: 9.1.0
+      resolve-from: 5.0.0
+      semver: 7.5.3
+      xml2js: 0.6.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
   /@expo/prebuild-config/6.2.6_pbseyuwvqr5k5dbbol4bevbrtu:
     resolution: {integrity: sha512-uFVvDAm9dPg9p1qpnr4CVnpo2hmkZIL5FQz+VlIdXXJpe7ySh/qTGHtKWY/lWUshQkAJ0nwbKGPztGWdABns/Q==}
     peerDependencies:
@@ -2496,15 +2497,13 @@ packages:
       '@floating-ui/utils': 0.1.1
     dev: false
 
-  /@floating-ui/react-native/0.10.1_6syixf76bqx5r4tgwtwyqyssoi:
+  /@floating-ui/react-native/0.10.1:
     resolution: {integrity: sha512-+GdYTrcZ9pD6+l63YU8hqCDZGsUeP4351kLY6dgjXUDYXYCr7M0rWnTWigVMOyafnDrTRXWxZxJbHo180+uFvQ==}
     peerDependencies:
       react: '>=16.8.0'
       react-native: '>=0.64.0'
     dependencies:
       '@floating-ui/core': 1.4.1
-      react: 18.2.0
-      react-native: 0.72.3_h5dl4kw4qyl3ku2pqfjzys6che
     dev: false
 
   /@floating-ui/utils/0.1.1:
@@ -2542,13 +2541,16 @@ packages:
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@humanwhocodes/module-importer/1.0.1:
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
+    dev: true
 
   /@humanwhocodes/object-schema/1.2.1:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
+    dev: true
 
   /@istanbuljs/load-nyc-config/1.1.0:
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
@@ -2825,6 +2827,7 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.19
+    dev: false
 
   /@jridgewell/sourcemap-codec/1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
@@ -3095,15 +3098,14 @@ packages:
     resolution: {integrity: sha512-Im93xRJuHHxb1wniGhBMsxLwcfzdYreSZVQGDoMJgkd6+Iky61LInGEHnQCTN0fKNYF1Dvcofb4uMmE1RQHXHQ==}
     dev: false
 
-  /@react-native/codegen/0.72.6_@babel+preset-env@7.22.14:
+  /@react-native/codegen/0.72.6:
     resolution: {integrity: sha512-idTVI1es/oopN0jJT/0jB6nKdvTUKE3757zA5+NPXZTeB46CIRbmmos4XBiAec8ufu9/DigLPbHTYAaMNZJ6Ig==}
     peerDependencies:
       '@babel/preset-env': ^7.1.6
     dependencies:
       '@babel/parser': 7.22.14
-      '@babel/preset-env': 7.22.14_@babel+core@7.22.11
       flow-parser: 0.206.0
-      jscodeshift: 0.14.0_@babel+preset-env@7.22.14
+      jscodeshift: 0.14.0
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
@@ -3132,7 +3134,7 @@ packages:
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
-      react-native: 0.72.3_h5dl4kw4qyl3ku2pqfjzys6che
+      react-native: 0.72.3_dyjrdn4cwwk5zc2yxh6dginkjq
     dev: false
 
   /@react-navigation/bottom-tabs/6.5.8_yu75tq5j2brzsa2nme6433wuti:
@@ -3148,7 +3150,7 @@ packages:
       '@react-navigation/native': 6.1.7_6syixf76bqx5r4tgwtwyqyssoi
       color: 4.2.3
       react: 18.2.0
-      react-native: 0.72.3_h5dl4kw4qyl3ku2pqfjzys6che
+      react-native: 0.72.3_dyjrdn4cwwk5zc2yxh6dginkjq
       react-native-safe-area-context: 4.6.3_6syixf76bqx5r4tgwtwyqyssoi
       react-native-screens: 3.22.1_6syixf76bqx5r4tgwtwyqyssoi
       warn-once: 0.1.1
@@ -3178,7 +3180,7 @@ packages:
     dependencies:
       '@react-navigation/native': 6.1.7_6syixf76bqx5r4tgwtwyqyssoi
       react: 18.2.0
-      react-native: 0.72.3_h5dl4kw4qyl3ku2pqfjzys6che
+      react-native: 0.72.3_dyjrdn4cwwk5zc2yxh6dginkjq
       react-native-safe-area-context: 4.6.3_6syixf76bqx5r4tgwtwyqyssoi
     dev: false
 
@@ -3194,7 +3196,7 @@ packages:
       '@react-navigation/elements': 1.3.18_626t6bmhebeldf75nh6d3awmry
       '@react-navigation/native': 6.1.7_6syixf76bqx5r4tgwtwyqyssoi
       react: 18.2.0
-      react-native: 0.72.3_h5dl4kw4qyl3ku2pqfjzys6che
+      react-native: 0.72.3_dyjrdn4cwwk5zc2yxh6dginkjq
       react-native-safe-area-context: 4.6.3_6syixf76bqx5r4tgwtwyqyssoi
       react-native-screens: 3.22.1_6syixf76bqx5r4tgwtwyqyssoi
       warn-once: 0.1.1
@@ -3211,7 +3213,7 @@ packages:
       fast-deep-equal: 3.1.3
       nanoid: 3.3.6
       react: 18.2.0
-      react-native: 0.72.3_h5dl4kw4qyl3ku2pqfjzys6che
+      react-native: 0.72.3_dyjrdn4cwwk5zc2yxh6dginkjq
     dev: false
 
   /@react-navigation/routers/6.1.9:
@@ -3225,26 +3227,6 @@ packages:
     dependencies:
       component-type: 1.2.1
       join-component: 1.1.0
-    dev: false
-
-  /@shopify/react-native-skia/0.1.196_6syixf76bqx5r4tgwtwyqyssoi:
-    resolution: {integrity: sha512-MwL+X9XzwPdyp5juOel6pNkd7DoRfPSbjqlkOTs5C83HCdceZOO0x6DMK9uiZv/mVxQwOnexfNh5h06185qiow==}
-    hasBin: true
-    requiresBuild: true
-    peerDependencies:
-      react: '>=18.0'
-      react-native: '>=0.64'
-      react-native-reanimated: '>=2.0.0'
-    peerDependenciesMeta:
-      react-native:
-        optional: true
-      react-native-reanimated:
-        optional: true
-    dependencies:
-      canvaskit-wasm: 0.38.0
-      react: 18.2.0
-      react-native: 0.72.3_h5dl4kw4qyl3ku2pqfjzys6che
-      react-reconciler: 0.27.0_react@18.2.0
     dev: false
 
   /@shopify/react-native-skia/0.1.196_exi4fzaxxqf7gmbnqtbekbtugq:
@@ -3263,8 +3245,8 @@ packages:
     dependencies:
       canvaskit-wasm: 0.38.0
       react: 18.2.0
-      react-native: 0.72.3_h5dl4kw4qyl3ku2pqfjzys6che
-      react-native-reanimated: 3.3.0_rbcj43ea2zki67y63rdmpi5f5e
+      react-native: 0.72.3_dyjrdn4cwwk5zc2yxh6dginkjq
+      react-native-reanimated: 3.3.0_c45zjcyxv4v5qicydpgeee2qeq
       react-reconciler: 0.27.0_react@18.2.0
     dev: false
 
@@ -3376,15 +3358,18 @@ packages:
     dependencies:
       '@types/eslint': 8.44.2
       '@types/estree': 1.0.1
+    dev: false
 
   /@types/eslint/8.44.2:
     resolution: {integrity: sha512-sdPRb9K6iL5XZOmBubg8yiFp5yS/JdUDQsq5e6h95km91MCYMuvp7mh1fjPEYUhvHepKpZOjnEaMBR4PxjWDzg==}
     dependencies:
       '@types/estree': 1.0.1
       '@types/json-schema': 7.0.12
+    dev: false
 
   /@types/estree/1.0.1:
     resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
+    dev: false
 
   /@types/express-serve-static-core/4.17.36:
     resolution: {integrity: sha512-zbivROJ0ZqLAtMzgzIUC4oNqDG9iF0lSsAqpOD9kbs5xcIM3dTiyuHvBc7R8MtWBp3AAWGaovJa+wzWPjLYW7Q==}
@@ -3587,7 +3572,7 @@ packages:
     dependencies:
       '@types/yargs-parser': 21.0.0
 
-  /@typescript-eslint/eslint-plugin/5.62.0_pv3pg3japumrjsd4wswxrcr33u:
+  /@typescript-eslint/eslint-plugin/5.62.0_ymvan467kgsinhigrcqohgvliu:
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3599,23 +3584,21 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.8.0
-      '@typescript-eslint/parser': 5.62.0_w2g2uv42be7wag4oipwkfv43p4
+      '@typescript-eslint/parser': 5.62.0
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0_w2g2uv42be7wag4oipwkfv43p4
-      '@typescript-eslint/utils': 5.62.0_w2g2uv42be7wag4oipwkfv43p4
+      '@typescript-eslint/type-utils': 5.62.0
+      '@typescript-eslint/utils': 5.62.0
       debug: 4.3.4
-      eslint: 8.48.0
       graphemer: 1.4.0
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
       semver: 7.5.4
-      tsutils: 3.21.0_typescript@5.2.2
-      typescript: 5.2.2
+      tsutils: 3.21.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/parser/5.62.0_w2g2uv42be7wag4oipwkfv43p4:
+  /@typescript-eslint/parser/5.62.0:
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3627,10 +3610,8 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0_typescript@5.2.2
+      '@typescript-eslint/typescript-estree': 5.62.0
       debug: 4.3.4
-      eslint: 8.48.0
-      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -3643,7 +3624,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.62.0
     dev: false
 
-  /@typescript-eslint/type-utils/5.62.0_w2g2uv42be7wag4oipwkfv43p4:
+  /@typescript-eslint/type-utils/5.62.0:
     resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3653,12 +3634,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0_typescript@5.2.2
-      '@typescript-eslint/utils': 5.62.0_w2g2uv42be7wag4oipwkfv43p4
+      '@typescript-eslint/typescript-estree': 5.62.0
+      '@typescript-eslint/utils': 5.62.0
       debug: 4.3.4
-      eslint: 8.48.0
-      tsutils: 3.21.0_typescript@5.2.2
-      typescript: 5.2.2
+      tsutils: 3.21.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -3668,7 +3647,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
-  /@typescript-eslint/typescript-estree/5.62.0_typescript@5.2.2:
+  /@typescript-eslint/typescript-estree/5.62.0:
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3683,25 +3662,23 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      tsutils: 3.21.0_typescript@5.2.2
-      typescript: 5.2.2
+      tsutils: 3.21.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/utils/5.62.0_w2g2uv42be7wag4oipwkfv43p4:
+  /@typescript-eslint/utils/5.62.0:
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0_eslint@8.48.0
+      '@eslint-community/eslint-utils': 4.4.0
       '@types/json-schema': 7.0.12
       '@types/semver': 7.5.1
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0_typescript@5.2.2
-      eslint: 8.48.0
+      '@typescript-eslint/typescript-estree': 5.62.0
       eslint-scope: 5.1.1
       semver: 7.5.4
     transitivePeerDependencies:
@@ -3742,15 +3719,19 @@ packages:
     dependencies:
       '@webassemblyjs/helper-numbers': 1.11.6
       '@webassemblyjs/helper-wasm-bytecode': 1.11.6
+    dev: false
 
   /@webassemblyjs/floating-point-hex-parser/1.11.6:
     resolution: {integrity: sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==}
+    dev: false
 
   /@webassemblyjs/helper-api-error/1.11.6:
     resolution: {integrity: sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==}
+    dev: false
 
   /@webassemblyjs/helper-buffer/1.11.6:
     resolution: {integrity: sha512-z3nFzdcp1mb8nEOFFk8DrYLpHvhKC3grJD2ardfKOzmbmJvEf/tPIqCY+sNcwZIY8ZD7IkB2l7/pqhUhqm7hLA==}
+    dev: false
 
   /@webassemblyjs/helper-numbers/1.11.6:
     resolution: {integrity: sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==}
@@ -3758,9 +3739,11 @@ packages:
       '@webassemblyjs/floating-point-hex-parser': 1.11.6
       '@webassemblyjs/helper-api-error': 1.11.6
       '@xtuc/long': 4.2.2
+    dev: false
 
   /@webassemblyjs/helper-wasm-bytecode/1.11.6:
     resolution: {integrity: sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==}
+    dev: false
 
   /@webassemblyjs/helper-wasm-section/1.11.6:
     resolution: {integrity: sha512-LPpZbSOwTpEC2cgn4hTydySy1Ke+XEu+ETXuoyvuyezHO3Kjdu90KK95Sh9xTbmjrCsUwvWwCOQQNta37VrS9g==}
@@ -3769,19 +3752,23 @@ packages:
       '@webassemblyjs/helper-buffer': 1.11.6
       '@webassemblyjs/helper-wasm-bytecode': 1.11.6
       '@webassemblyjs/wasm-gen': 1.11.6
+    dev: false
 
   /@webassemblyjs/ieee754/1.11.6:
     resolution: {integrity: sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==}
     dependencies:
       '@xtuc/ieee754': 1.2.0
+    dev: false
 
   /@webassemblyjs/leb128/1.11.6:
     resolution: {integrity: sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==}
     dependencies:
       '@xtuc/long': 4.2.2
+    dev: false
 
   /@webassemblyjs/utf8/1.11.6:
     resolution: {integrity: sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==}
+    dev: false
 
   /@webassemblyjs/wasm-edit/1.11.6:
     resolution: {integrity: sha512-Ybn2I6fnfIGuCR+Faaz7YcvtBKxvoLV3Lebn1tM4o/IAJzmi9AWYIPWpyBfU8cC+JxAO57bk4+zdsTjJR+VTOw==}
@@ -3794,6 +3781,7 @@ packages:
       '@webassemblyjs/wasm-opt': 1.11.6
       '@webassemblyjs/wasm-parser': 1.11.6
       '@webassemblyjs/wast-printer': 1.11.6
+    dev: false
 
   /@webassemblyjs/wasm-gen/1.11.6:
     resolution: {integrity: sha512-3XOqkZP/y6B4F0PBAXvI1/bky7GryoogUtfwExeP/v7Nzwo1QLcq5oQmpKlftZLbT+ERUOAZVQjuNVak6UXjPA==}
@@ -3803,6 +3791,7 @@ packages:
       '@webassemblyjs/ieee754': 1.11.6
       '@webassemblyjs/leb128': 1.11.6
       '@webassemblyjs/utf8': 1.11.6
+    dev: false
 
   /@webassemblyjs/wasm-opt/1.11.6:
     resolution: {integrity: sha512-cOrKuLRE7PCe6AsOVl7WasYf3wbSo4CeOk6PkrjS7g57MFfVUF9u6ysQBBODX0LdgSvQqRiGz3CXvIDKcPNy4g==}
@@ -3811,6 +3800,7 @@ packages:
       '@webassemblyjs/helper-buffer': 1.11.6
       '@webassemblyjs/wasm-gen': 1.11.6
       '@webassemblyjs/wasm-parser': 1.11.6
+    dev: false
 
   /@webassemblyjs/wasm-parser/1.11.6:
     resolution: {integrity: sha512-6ZwPeGzMJM3Dqp3hCsLgESxBGtT/OeCvCZ4TA1JUPYgmhAx38tTPR9JaKy0S5H3evQpO/h2uWs2j6Yc/fjkpTQ==}
@@ -3821,12 +3811,14 @@ packages:
       '@webassemblyjs/ieee754': 1.11.6
       '@webassemblyjs/leb128': 1.11.6
       '@webassemblyjs/utf8': 1.11.6
+    dev: false
 
   /@webassemblyjs/wast-printer/1.11.6:
     resolution: {integrity: sha512-JM7AhRcE+yW2GWYaKeHL5vt4xqee5N2WcezptmgyhNS+ScggqcT1OtXykhAb13Sn5Yas0j2uv9tHgrjwvzAP4A==}
     dependencies:
       '@webassemblyjs/ast': 1.11.6
       '@xtuc/long': 4.2.2
+    dev: false
 
   /@xmldom/xmldom/0.7.13:
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
@@ -3840,9 +3832,11 @@ packages:
 
   /@xtuc/ieee754/1.2.0:
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
+    dev: false
 
   /@xtuc/long/4.2.2:
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
+    dev: false
 
   /abab/2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
@@ -3869,6 +3863,7 @@ packages:
       acorn: ^8
     dependencies:
       acorn: 8.10.0
+    dev: false
 
   /acorn-jsx/5.3.2_acorn@8.10.0:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -3876,6 +3871,7 @@ packages:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       acorn: 8.10.0
+    dev: true
 
   /acorn-walk/8.2.0:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
@@ -3904,10 +3900,8 @@ packages:
       indent-string: 4.0.0
     dev: false
 
-  /ajv-formats/2.1.1_ajv@8.12.0:
+  /ajv-formats/2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -4224,6 +4218,21 @@ packages:
       make-dir: 3.1.0
       schema-utils: 2.7.1
       webpack: 5.88.2
+    dev: false
+
+  /babel-loader/8.3.0_@babel+core@7.22.11:
+    resolution: {integrity: sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==}
+    engines: {node: '>= 8.9'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      webpack: '>=2'
+    dependencies:
+      '@babel/core': 7.22.11
+      find-cache-dir: 3.3.2
+      loader-utils: 2.0.4
+      make-dir: 3.1.0
+      schema-utils: 2.7.1
+    dev: true
 
   /babel-plugin-istanbul/6.1.1:
     resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
@@ -4673,6 +4682,7 @@ packages:
   /callsites/3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
+    dev: true
 
   /camel-case/4.1.2:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
@@ -4764,6 +4774,7 @@ packages:
   /chrome-trace-event/1.0.3:
     resolution: {integrity: sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==}
     engines: {node: '>=6.0'}
+    dev: false
 
   /ci-info/2.0.0:
     resolution: {integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==}
@@ -4925,6 +4936,7 @@ packages:
 
   /commander/2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+    dev: false
 
   /commander/4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -5384,6 +5396,7 @@ packages:
 
   /deep-is/0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+    dev: true
 
   /deepmerge/4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
@@ -5544,6 +5557,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       esutils: 2.0.3
+    dev: true
 
   /dom-converter/0.2.0:
     resolution: {integrity: sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==}
@@ -5654,6 +5668,7 @@ packages:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
+    dev: false
 
   /enquirer/2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
@@ -5752,6 +5767,7 @@ packages:
 
   /es-module-lexer/1.3.0:
     resolution: {integrity: sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA==}
+    dev: false
 
   /es-set-tostringtag/2.0.1:
     resolution: {integrity: sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==}
@@ -5824,13 +5840,11 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  /eslint-config-prettier/9.0.0_eslint@8.48.0:
+  /eslint-config-prettier/9.0.0:
     resolution: {integrity: sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
-    dependencies:
-      eslint: 8.48.0
     dev: false
 
   /eslint-import-resolver-node/0.3.9:
@@ -5843,7 +5857,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-import-resolver-typescript/3.6.0_rksubgp4nk5ffepfua3qexp6q4:
+  /eslint-import-resolver-typescript/3.6.0_57gzdhhtk7qjbqqkq5tdmx2zhu:
     resolution: {integrity: sha512-QTHR9ddNnn35RTxlaEnx2gCxqFlF2SEN0SE2d17SqwyM7YOSI2GHWRYp5BiRkObTUNYPupC/3Fq2a0PpT+EKpg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -5852,9 +5866,8 @@ packages:
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
-      eslint: 8.48.0
-      eslint-module-utils: 2.8.0_op7bh4tdgs2eg2llb7ukqwpcza
-      eslint-plugin-import: 2.28.1_op7bh4tdgs2eg2llb7ukqwpcza
+      eslint-module-utils: 2.8.0_tuirrgthw55etjceyndomyqnfa
+      eslint-plugin-import: 2.28.1_tuirrgthw55etjceyndomyqnfa
       fast-glob: 3.3.1
       get-tsconfig: 4.7.0
       is-core-module: 2.13.0
@@ -5866,7 +5879,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-module-utils/2.8.0_op7bh4tdgs2eg2llb7ukqwpcza:
+  /eslint-module-utils/2.8.0_tuirrgthw55etjceyndomyqnfa:
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -5887,15 +5900,14 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0_w2g2uv42be7wag4oipwkfv43p4
+      '@typescript-eslint/parser': 5.62.0
       debug: 3.2.7
-      eslint: 8.48.0
-      eslint-import-resolver-typescript: 3.6.0_rksubgp4nk5ffepfua3qexp6q4
+      eslint-import-resolver-typescript: 3.6.0_57gzdhhtk7qjbqqkq5tdmx2zhu
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /eslint-module-utils/2.8.0_tvlsg6shq6cwysgwdbrh5q4zii:
+  /eslint-module-utils/2.8.0_xjminl3smz372lv3q4ck3okk7y:
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -5916,27 +5928,25 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0_w2g2uv42be7wag4oipwkfv43p4
+      '@typescript-eslint/parser': 5.62.0
       debug: 3.2.7
-      eslint: 8.48.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.0_rksubgp4nk5ffepfua3qexp6q4
+      eslint-import-resolver-typescript: 3.6.0_57gzdhhtk7qjbqqkq5tdmx2zhu
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /eslint-plugin-eslint-comments/3.2.0_eslint@8.48.0:
+  /eslint-plugin-eslint-comments/3.2.0:
     resolution: {integrity: sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==}
     engines: {node: '>=6.5.0'}
     peerDependencies:
       eslint: '>=4.19.1'
     dependencies:
       escape-string-regexp: 1.0.5
-      eslint: 8.48.0
       ignore: 5.2.4
     dev: false
 
-  /eslint-plugin-import/2.28.1_op7bh4tdgs2eg2llb7ukqwpcza:
+  /eslint-plugin-import/2.28.1_tuirrgthw55etjceyndomyqnfa:
     resolution: {integrity: sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -5946,16 +5956,15 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0_w2g2uv42be7wag4oipwkfv43p4
+      '@typescript-eslint/parser': 5.62.0
       array-includes: 3.1.6
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 8.48.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0_tvlsg6shq6cwysgwdbrh5q4zii
+      eslint-module-utils: 2.8.0_xjminl3smz372lv3q4ck3okk7y
       has: 1.0.3
       is-core-module: 2.13.0
       is-glob: 4.0.3
@@ -5971,16 +5980,14 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-plugin-react-hooks/4.6.0_eslint@8.48.0:
+  /eslint-plugin-react-hooks/4.6.0:
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
-    dependencies:
-      eslint: 8.48.0
     dev: false
 
-  /eslint-plugin-react/7.32.2_eslint@8.48.0:
+  /eslint-plugin-react/7.32.2:
     resolution: {integrity: sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -5990,7 +5997,6 @@ packages:
       array.prototype.flatmap: 1.3.1
       array.prototype.tosorted: 1.1.1
       doctrine: 2.1.0
-      eslint: 8.48.0
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.5
       minimatch: 3.1.2
@@ -6004,12 +6010,10 @@ packages:
       string.prototype.matchall: 4.0.9
     dev: false
 
-  /eslint-plugin-simple-import-sort/10.0.0_eslint@8.48.0:
+  /eslint-plugin-simple-import-sort/10.0.0:
     resolution: {integrity: sha512-AeTvO9UCMSNzIHRkg8S6c3RPy5YEwKWSQPx3DYghLedo2ZQxowPFLGDN1AZ2evfg6r6mjBSZSLxLFsWSu3acsw==}
     peerDependencies:
       eslint: '>=5.0.0'
-    dependencies:
-      eslint: 8.48.0
     dev: false
 
   /eslint-scope/5.1.1:
@@ -6018,6 +6022,7 @@ packages:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 4.3.0
+    dev: false
 
   /eslint-scope/7.2.2:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
@@ -6025,6 +6030,7 @@ packages:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
+    dev: true
 
   /eslint-visitor-keys/3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
@@ -6074,6 +6080,7 @@ packages:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /espree/9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
@@ -6082,6 +6089,7 @@ packages:
       acorn: 8.10.0
       acorn-jsx: 5.3.2_acorn@8.10.0
       eslint-visitor-keys: 3.4.3
+    dev: true
 
   /esprima/4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
@@ -6093,6 +6101,7 @@ packages:
     engines: {node: '>=0.10'}
     dependencies:
       estraverse: 5.3.0
+    dev: true
 
   /esrecurse/4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -6103,6 +6112,7 @@ packages:
   /estraverse/4.3.0:
     resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
     engines: {node: '>=4.0'}
+    dev: false
 
   /estraverse/5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
@@ -6129,6 +6139,7 @@ packages:
   /events/3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+    dev: false
 
   /exec-async/2.2.0:
     resolution: {integrity: sha512-87OpwcEiMia/DeiKFzaQNBNFeN3XkkpYIh9FyOqq5mS2oKv3CBE67PXoEKcr6nodWdXNogTiQ0jE2NGuoffXPw==}
@@ -6304,12 +6315,12 @@ packages:
       - encoding
     dev: false
 
-  /expo-splash-screen/0.20.5_5pnih3po4zk6kucbfu7de2bahi:
+  /expo-splash-screen/0.20.5_expo@49.0.8:
     resolution: {integrity: sha512-nTALYdjHpeEA30rdOWSguxn72ctv8WM8ptuUgpfRgsWyn4i6rwYds/rBXisX69XO5fg+XjHAQqijGx/b28+3tg==}
     peerDependencies:
       expo: '*'
     dependencies:
-      '@expo/prebuild-config': 6.2.6_pbseyuwvqr5k5dbbol4bevbrtu
+      '@expo/prebuild-config': 6.2.6
       expo: 49.0.8_@babel+core@7.22.11
     transitivePeerDependencies:
       - encoding
@@ -6446,6 +6457,7 @@ packages:
 
   /fast-levenshtein/2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+    dev: true
 
   /fast-loops/1.1.3:
     resolution: {integrity: sha512-8EZzEP0eKkEEVX+drtd9mtuQ+/QrlfW/5MlwcwK5Nds6EkZ/tRzEexkzUY2mIssnAyVLT+TKHuRXmFNNXYUd6g==}
@@ -6510,6 +6522,7 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
       flat-cache: 3.1.0
+    dev: true
 
   /fill-range/7.0.1:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
@@ -6618,9 +6631,11 @@ packages:
       flatted: 3.2.7
       keyv: 4.5.3
       rimraf: 3.0.2
+    dev: true
 
   /flatted/3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
+    dev: true
 
   /flow-enums-runtime/0.0.5:
     resolution: {integrity: sha512-PSZF9ZuaZD03sT9YaIs0FrGJ7lSUw7rHZIex+73UYVXg46eL/wxN5PaVcPJFudE2cJu5f0fezitV5aBkLHPUOQ==}
@@ -6834,6 +6849,7 @@ packages:
 
   /glob-to-regexp/0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+    dev: false
 
   /glob/6.0.4:
     resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==}
@@ -6886,6 +6902,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
+    dev: true
 
   /globalthis/1.0.3:
     resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}
@@ -7241,6 +7258,7 @@ packages:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+    dev: true
 
   /import-local/3.1.0:
     resolution: {integrity: sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==}
@@ -8071,6 +8089,7 @@ packages:
       '@types/node': 18.17.12
       merge-stream: 2.0.0
       supports-color: 8.1.1
+    dev: false
 
   /jest-worker/29.6.4:
     resolution: {integrity: sha512-6dpvFV4WjcWbDVGgHTWo/aupl8/LbBx2NSKfiwqf79xC/yeJjKHT1+StcKy/2KTmW16hE68ccKVOtXf+WZGz7Q==}
@@ -8150,7 +8169,7 @@ packages:
     resolution: {integrity: sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==}
     dev: false
 
-  /jscodeshift/0.14.0_@babel+preset-env@7.22.14:
+  /jscodeshift/0.14.0:
     resolution: {integrity: sha512-7eCC1knD7bLUPuSCwXsMZUH51O8jIcoVyKtI6P0XM0IVzlGjckPy3FIwQlorzbN0Sg79oK+RlohN32Mqf/lrYA==}
     hasBin: true
     peerDependencies:
@@ -8162,7 +8181,6 @@ packages:
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.22.11
       '@babel/plugin-proposal-optional-chaining': 7.21.0_@babel+core@7.22.11
       '@babel/plugin-transform-modules-commonjs': 7.22.11_@babel+core@7.22.11
-      '@babel/preset-env': 7.22.14_@babel+core@7.22.11
       '@babel/preset-flow': 7.22.5_@babel+core@7.22.11
       '@babel/preset-typescript': 7.22.11_@babel+core@7.22.11
       '@babel/register': 7.22.5_@babel+core@7.22.11
@@ -8192,6 +8210,7 @@ packages:
 
   /json-buffer/3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+    dev: true
 
   /json-parse-better-errors/1.0.2:
     resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
@@ -8231,6 +8250,7 @@ packages:
 
   /json-stable-stringify-without-jsonify/1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+    dev: true
 
   /json5/1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
@@ -8270,6 +8290,7 @@ packages:
     resolution: {integrity: sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==}
     dependencies:
       json-buffer: 3.0.1
+    dev: true
 
   /kind-of/6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -8301,6 +8322,7 @@ packages:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+    dev: true
 
   /lightningcss-darwin-arm64/1.19.0:
     resolution: {integrity: sha512-wIJmFtYX0rXHsXHSr4+sC5clwblEMji7HHQ4Ub1/CznVRxtCFha6JIt5JZaNf8vQrfdZnBxLLC6R8pC818jXqg==}
@@ -8415,6 +8437,7 @@ packages:
   /loader-runner/4.3.0:
     resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
     engines: {node: '>=6.11.5'}
+    dev: false
 
   /loader-utils/2.0.4:
     resolution: {integrity: sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==}
@@ -8453,6 +8476,7 @@ packages:
 
   /lodash.merge/4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+    dev: true
 
   /lodash.sortby/4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
@@ -9023,12 +9047,14 @@ packages:
   /mime-db/1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
+    dev: false
 
   /mime-types/2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.52.0
+    dev: false
 
   /mime/1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
@@ -9202,6 +9228,7 @@ packages:
 
   /natural-compare/1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+    dev: true
 
   /ncp/2.0.0:
     resolution: {integrity: sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==}
@@ -9488,6 +9515,7 @@ packages:
       levn: 0.4.1
       prelude-ls: 1.2.1
       type-check: 0.4.0
+    dev: true
 
   /ora/3.4.0:
     resolution: {integrity: sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==}
@@ -9614,6 +9642,7 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       callsites: 3.1.0
+    dev: true
 
   /parse-json/4.0.0:
     resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==}
@@ -10140,6 +10169,7 @@ packages:
   /prelude-ls/1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+    dev: true
 
   /prepend-http/2.0.0:
     resolution: {integrity: sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==}
@@ -10327,6 +10357,7 @@ packages:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
     dependencies:
       safe-buffer: 5.2.1
+    dev: false
 
   /range-parser/1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -10414,10 +10445,10 @@ packages:
       lodash: 4.17.21
       prop-types: 15.8.1
       react: 18.2.0
-      react-native: 0.72.3_h5dl4kw4qyl3ku2pqfjzys6che
+      react-native: 0.72.3_dyjrdn4cwwk5zc2yxh6dginkjq
     dev: false
 
-  /react-native-reanimated/3.3.0_rbcj43ea2zki67y63rdmpi5f5e:
+  /react-native-reanimated/3.3.0_c45zjcyxv4v5qicydpgeee2qeq:
     resolution: {integrity: sha512-LzfpPZ1qXBGy5BcUHqw3pBC0qSd22qXS3t8hWSbozXNrBkzMhhOrcILE/nEg/PHpNNp1xvGOW8NwpAMF006roQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -10430,17 +10461,12 @@ packages:
       react-native: '*'
     dependencies:
       '@babel/core': 7.22.11
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.22.11
-      '@babel/plugin-proposal-optional-chaining': 7.21.0_@babel+core@7.22.11
-      '@babel/plugin-transform-arrow-functions': 7.22.5_@babel+core@7.22.11
       '@babel/plugin-transform-object-assign': 7.22.5_@babel+core@7.22.11
-      '@babel/plugin-transform-shorthand-properties': 7.22.5_@babel+core@7.22.11
-      '@babel/plugin-transform-template-literals': 7.22.5_@babel+core@7.22.11
       '@babel/preset-typescript': 7.22.11_@babel+core@7.22.11
       convert-source-map: 2.0.0
       invariant: 2.2.4
       react: 18.2.0
-      react-native: 0.72.3_h5dl4kw4qyl3ku2pqfjzys6che
+      react-native: 0.72.3_dyjrdn4cwwk5zc2yxh6dginkjq
     dev: false
 
   /react-native-safe-area-context/4.6.3_6syixf76bqx5r4tgwtwyqyssoi:
@@ -10450,7 +10476,7 @@ packages:
       react-native: '*'
     dependencies:
       react: 18.2.0
-      react-native: 0.72.3_h5dl4kw4qyl3ku2pqfjzys6che
+      react-native: 0.72.3_dyjrdn4cwwk5zc2yxh6dginkjq
     dev: false
 
   /react-native-screens/3.22.1_6syixf76bqx5r4tgwtwyqyssoi:
@@ -10461,7 +10487,7 @@ packages:
     dependencies:
       react: 18.2.0
       react-freeze: 1.0.3_react@18.2.0
-      react-native: 0.72.3_h5dl4kw4qyl3ku2pqfjzys6che
+      react-native: 0.72.3_dyjrdn4cwwk5zc2yxh6dginkjq
       warn-once: 0.1.1
     dev: false
 
@@ -10474,7 +10500,7 @@ packages:
       css-select: 5.1.0
       css-tree: 1.1.3
       react: 18.2.0
-      react-native: 0.72.3_h5dl4kw4qyl3ku2pqfjzys6che
+      react-native: 0.72.3_dyjrdn4cwwk5zc2yxh6dginkjq
     dev: false
 
   /react-native-web/0.19.8_biqbaboplfbrettd7655fr4n2y:
@@ -10497,7 +10523,7 @@ packages:
       - encoding
     dev: false
 
-  /react-native/0.72.3_h5dl4kw4qyl3ku2pqfjzys6che:
+  /react-native/0.72.3_dyjrdn4cwwk5zc2yxh6dginkjq:
     resolution: {integrity: sha512-QqISi+JVmCssNP2FlQ4MWhlc4O/I00MRE1/GClvyZ8h/6kdsyk/sOirkYdZqX3+DrJfI3q+OnyMnsyaXIQ/5tQ==}
     engines: {node: '>=16'}
     hasBin: true
@@ -10509,7 +10535,7 @@ packages:
       '@react-native-community/cli-platform-android': 11.3.5
       '@react-native-community/cli-platform-ios': 11.3.5
       '@react-native/assets-registry': 0.72.0
-      '@react-native/codegen': 0.72.6_@babel+preset-env@7.22.14
+      '@react-native/codegen': 0.72.6
       '@react-native/gradle-plugin': 0.72.11
       '@react-native/js-polyfills': 0.72.1
       '@react-native/normalize-colors': 0.72.0
@@ -10798,6 +10824,7 @@ packages:
   /resolve-from/4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+    dev: true
 
   /resolve-from/5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -10916,6 +10943,7 @@ packages:
 
   /safe-buffer/5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: false
 
   /safe-json-stringify/1.2.0:
     resolution: {integrity: sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==}
@@ -10976,6 +11004,7 @@ packages:
       '@types/json-schema': 7.0.12
       ajv: 6.12.6
       ajv-keywords: 3.5.2_ajv@6.12.6
+    dev: false
 
   /schema-utils/4.2.0:
     resolution: {integrity: sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==}
@@ -10983,7 +11012,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.12
       ajv: 8.12.0
-      ajv-formats: 2.1.1_ajv@8.12.0
+      ajv-formats: 2.1.1
       ajv-keywords: 5.1.0_ajv@8.12.0
     dev: false
 
@@ -11072,6 +11101,7 @@ packages:
     resolution: {integrity: sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==}
     dependencies:
       randombytes: 2.1.0
+    dev: false
 
   /serve-index/1.9.1:
     resolution: {integrity: sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==}
@@ -11257,6 +11287,7 @@ packages:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
+    dev: false
 
   /source-map/0.5.7:
     resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
@@ -11517,6 +11548,7 @@ packages:
   /strip-json-comments/3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+    dev: true
 
   /strnum/1.0.5:
     resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
@@ -11622,6 +11654,7 @@ packages:
   /tapable/2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
+    dev: false
 
   /tar/6.1.15:
     resolution: {integrity: sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==}
@@ -11707,6 +11740,7 @@ packages:
       serialize-javascript: 6.0.1
       terser: 5.19.3
       webpack: 5.88.2
+    dev: false
 
   /terser/5.19.3:
     resolution: {integrity: sha512-pQzJ9UJzM0IgmT4FAtYI6+VqFf0lj/to58AV0Xfgg0Up37RyPG7Al+1cepC6/BVuAxR9oNb41/DL4DEoHJvTdg==}
@@ -11717,6 +11751,7 @@ packages:
       acorn: 8.10.0
       commander: 2.20.3
       source-map-support: 0.5.21
+    dev: false
 
   /test-exclude/6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
@@ -11811,7 +11846,7 @@ packages:
   /ts-interface-checker/0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
-  /ts-jest/29.1.1_csrhwi5xvc6uasz2wtwewilb5m:
+  /ts-jest/29.1.1_viekctkmyg3fwkrpb5gzerjumy:
     resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -11832,9 +11867,7 @@ packages:
       esbuild:
         optional: true
     dependencies:
-      '@babel/core': 7.22.11
       bs-logger: 0.2.6
-      esbuild: 0.18.20
       fast-json-stable-stringify: 2.1.0
       jest: 29.6.4_dxriesx7donpxdng6xmr42kubu
       jest-util: 29.6.3
@@ -11929,14 +11962,13 @@ packages:
       - ts-node
     dev: true
 
-  /tsutils/3.21.0_typescript@5.2.2:
+  /tsutils/3.21.0:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.2.2
     dev: false
 
   /tty-table/4.2.1:
@@ -12018,6 +12050,7 @@ packages:
     engines: {node: '>= 0.8.0'}
     dependencies:
       prelude-ls: 1.2.1
+    dev: true
 
   /type-detect/4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
@@ -12041,6 +12074,7 @@ packages:
   /type-fest/0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
+    dev: true
 
   /type-fest/0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
@@ -12112,6 +12146,7 @@ packages:
     resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
     engines: {node: '>=14.17'}
     hasBin: true
+    dev: true
 
   /ua-parser-js/1.0.35:
     resolution: {integrity: sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==}
@@ -12349,6 +12384,7 @@ packages:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
+    dev: false
 
   /wbuf/1.7.3:
     resolution: {integrity: sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==}
@@ -12456,6 +12492,7 @@ packages:
   /webpack-sources/3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
     engines: {node: '>=10.13.0'}
+    dev: false
 
   /webpack/5.88.2:
     resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}
@@ -12495,6 +12532,7 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
+    dev: false
 
   /websocket-driver/0.7.4:
     resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}


### PR DESCRIPTION
- set `@equinor/mad-components` to normal dependency in `@equinor/mad-navigation`.
- reinstall. 
- export `EnvironmentProvider` through `@equinor/mad-navigation`
- set Chronicles to use newly exported provider