### PR TITLE
feat: add `Cell.Switch` component

### DIFF
--- a/.changeset/green-crabs-march.md
+++ b/.changeset/green-crabs-march.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-components": patch
+---
+
+Added `Cell.Switch`component

--- a/apps/chronicles/navigation/index.tsx
+++ b/apps/chronicles/navigation/index.tsx
@@ -35,6 +35,7 @@ import { PortalScreen } from "../screens/components/PortalScreen";
 import { DialogScreen } from "../screens/components/DialogScreen";
 import { EnvironmentScreen } from "../screens/components/EnvironmentScreen";
 import { ButtonCellScreen } from "../screens/components/ButtonCellScreen";
+import { SwitchCellScreen } from "../screens/components/SwitchCellScreen";
 import { trackNavigation } from "@equinor/mad-insights";
 import { SwitchScreen } from "../screens/components/SwitchScreen";
 
@@ -113,6 +114,7 @@ function DiscoverNavigator() {
             <DiscoverStack.Screen name="Cell" component={CellScreen} />
             <DiscoverStack.Screen name="NavigationCell" component={NavigationCellScreen} />
             <DiscoverStack.Screen name="ButtonCell" component={ButtonCellScreen} />
+            <DiscoverStack.Screen name="SwitchCell" component={SwitchCellScreen} />
             <DiscoverStack.Screen name="Accordion" component={AccordionScreen} />
             <DiscoverStack.Screen name="Menu" component={MenuScreen} />
             <DiscoverStack.Screen

--- a/apps/chronicles/screens/DiscoverScreen.tsx
+++ b/apps/chronicles/screens/DiscoverScreen.tsx
@@ -117,6 +117,12 @@ export default function DiscoverScreen({
                     iconName="gesture-tap-button"
                     onPress={() => navigation.navigate("ButtonCell")}
                 />
+                <Cell.Navigation
+                    title="Switch Cell"
+                    description="Toggle me!"
+                    iconName="toggle-switch"
+                    onPress={() => navigation.navigate("SwitchCell")}
+                />
             </Cell.Group>
 
             <Spacer />

--- a/apps/chronicles/screens/components/SwitchCellScreen.tsx
+++ b/apps/chronicles/screens/components/SwitchCellScreen.tsx
@@ -1,12 +1,5 @@
 import React, { useState } from "react";
-import {
-    Cell,
-    EDSStyleSheet,
-    Spacer,
-    Typography,
-    useStyles,
-    Switch,
-} from "@equinor/mad-components";
+import { Cell, EDSStyleSheet, Spacer, Typography, useStyles } from "@equinor/mad-components";
 import { ScrollView, View } from "react-native";
 
 export const SwitchCellScreen = () => {
@@ -15,7 +8,6 @@ export const SwitchCellScreen = () => {
     const [activeSwitch1, setActiveSwitch1] = useState(false);
     const [activeSwitch2, setActiveSwitch2] = useState(true);
     const [activeSwitch3, setActiveSwitch3] = useState(false);
-    const [disabledSwitch, setDisabledSwitch] = useState(true);
 
     return (
         <ScrollView
@@ -44,7 +36,7 @@ export const SwitchCellScreen = () => {
                 title="I'm the forbidden switch. No touchy!"
                 isActive={activeSwitch2}
                 onChange={setActiveSwitch2}
-                disabled={disabledSwitch}
+                disabled={true}
             />
             <Spacer />
             <Typography style={styles.explanation}>

--- a/apps/chronicles/screens/components/SwitchCellScreen.tsx
+++ b/apps/chronicles/screens/components/SwitchCellScreen.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from "react";
+import {
+    Cell,
+    EDSStyleSheet,
+    Spacer,
+    Typography,
+    useStyles,
+    Switch,
+} from "@equinor/mad-components";
+import { ScrollView, View } from "react-native";
+
+export const SwitchCellScreen = () => {
+    const styles = useStyles(themeStyles);
+
+    const [activeSwitch1, setActiveSwitch1] = useState(false);
+    const [activeSwitch2, setActiveSwitch2] = useState(true);
+    const [activeSwitch3, setActiveSwitch3] = useState(false);
+    const [disabledSwitch, setDisabledSwitch] = useState(true);
+
+    return (
+        <ScrollView
+            contentInsetAdjustmentBehavior="automatic"
+            contentContainerStyle={styles.container}
+        >
+            <View style={styles.readableContent}>
+                <Typography>{"Let's switch things up a bit, shall we?"}</Typography>
+            </View>
+            <Spacer />
+
+            <Cell.Switch
+                title="Who's up for a little toggle party?"
+                isActive={activeSwitch1}
+                onChange={setActiveSwitch1}
+            />
+            <Spacer />
+            <Typography style={styles.explanation}>
+                {
+                    "Here's a standard switch. Toggle it for a fun surprise! (Just kidding, it'll just toggle.)"
+                }
+            </Typography>
+            <Spacer />
+
+            <Cell.Switch
+                title="I'm the forbidden switch. No touchy!"
+                isActive={activeSwitch2}
+                onChange={setActiveSwitch2}
+                disabled={disabledSwitch}
+            />
+            <Spacer />
+            <Typography style={styles.explanation}>
+                This switch is disabled, so no funny business here. Move along!
+            </Typography>
+            <Spacer />
+
+            <Cell.Switch
+                title="Caution! This switch is spicy!"
+                isActive={activeSwitch3}
+                onChange={setActiveSwitch3}
+                color="danger"
+                iconName="alert"
+                switchSize="normal"
+            />
+            <Spacer />
+            <Typography style={styles.explanation}>
+                Watch out! This switch has a dash of danger and an extra icon for added flavor.
+            </Typography>
+            <Spacer />
+        </ScrollView>
+    );
+};
+
+const themeStyles = EDSStyleSheet.create(theme => ({
+    container: {
+        paddingVertical: theme.spacing.container.paddingVertical,
+    },
+    readableContent: {
+        paddingHorizontal: theme.spacing.container.paddingHorizontal,
+    },
+    explanation: {
+        paddingHorizontal: theme.spacing.container.paddingHorizontal,
+        fontStyle: "italic",
+    },
+}));

--- a/packages/components/src/components/Cell/SwitchCell.tsx
+++ b/packages/components/src/components/Cell/SwitchCell.tsx
@@ -1,0 +1,99 @@
+import React, { forwardRef } from "react";
+import { View } from "react-native";
+import { useStyles } from "../../hooks/useStyles";
+import { EDSStyleSheet } from "../../styling";
+import { Icon, IconName } from "../Icon";
+import { Cell, CellProps } from "./Cell";
+import { Typography } from "../Typography";
+import { Switch } from "../Switch";
+
+type SwitchColor = "textPrimary" | "danger" | "warning" | "textDisabled"; // Add more as needed
+
+export type SwitchCellProps = {
+    isActive: boolean;
+    onChange: (isActive: boolean) => void;
+    switchSize?: "small" | "normal";
+    disabled?: boolean;
+    title: string;
+    description?: string;
+    iconName?: IconName;
+    color?: SwitchColor;
+} & Omit<CellProps, "leftAdornment" | "rightAdornment">;
+
+export const SwitchCell = forwardRef<View, SwitchCellProps>(
+    (
+        {
+            isActive,
+            onChange,
+            switchSize = "small",
+            disabled = false,
+            title,
+            description,
+            iconName,
+            color,
+            ...rest
+        },
+        ref,
+    ) => {
+        const styles = useStyles(themeStyles);
+
+        const IconAdornment = () =>
+            iconName && (
+                <View style={styles.iconContainer}>
+                    <Icon name={iconName} color={color} />
+                </View>
+            );
+
+        const SwitchAdornment =
+            switchSize === "small" ? (
+                <Switch.Small active={isActive} onChange={onChange} disabled={disabled} />
+            ) : (
+                <Switch active={isActive} onChange={onChange} disabled={disabled} />
+            );
+
+        return (
+            <Cell
+                {...rest}
+                leftAdornment={IconAdornment()}
+                rightAdornment={SwitchAdornment}
+                ref={ref}
+            >
+                <View style={styles.contentContainer}>
+                    <Typography
+                        group="cell"
+                        variant="title"
+                        numberOfLines={1}
+                        color={disabled ? "textDisabled" : color}
+                    >
+                        {title}
+                    </Typography>
+                    {description && (
+                        <Typography
+                            group="cell"
+                            variant="description"
+                            numberOfLines={2}
+                            color={disabled ? "textDisabled" : undefined}
+                        >
+                            {description}
+                        </Typography>
+                    )}
+                </View>
+            </Cell>
+        );
+    },
+);
+
+SwitchCell.displayName = "Cell.Switch";
+
+const themeStyles = EDSStyleSheet.create(theme => ({
+    contentContainer: {
+        flex: 1,
+        justifyContent: "center",
+        gap: theme.spacing.cell.content.titleDescriptionGap,
+    },
+    iconContainer: {
+        flex: 1,
+        justifyContent: "center",
+        alignItems: "center",
+    },
+}));

--- a/packages/components/src/components/Cell/SwitchCell.tsx
+++ b/packages/components/src/components/Cell/SwitchCell.tsx
@@ -72,7 +72,7 @@ export const SwitchCell = forwardRef<View, SwitchCellProps>(
                             group="cell"
                             variant="description"
                             numberOfLines={2}
-                            color={disabled ? "textDisabled" : undefined}
+                            color={disabled ? "textDisabled" : "textTertiary"}
                         >
                             {description}
                         </Typography>

--- a/packages/components/src/components/Cell/index.ts
+++ b/packages/components/src/components/Cell/index.ts
@@ -3,6 +3,7 @@ import { NavigationCell, NavigationCellProps } from "./NavigationCell";
 import { Cell as _Cell, CellProps } from "./Cell";
 import { CellSwipeItemProps } from "./types";
 import { ButtonCell } from "./ButtonCell";
+import { SwitchCell } from "./SwitchCell";
 
 type CellFamily = typeof _Cell & {
     /**
@@ -17,11 +18,14 @@ type CellFamily = typeof _Cell & {
      * A cell with button interaction.
      */
     Button: typeof ButtonCell;
+
+    Switch: typeof SwitchCell;
 };
 
 const Cell = _Cell as CellFamily;
 Cell.Group = CellGroup;
 Cell.Navigation = NavigationCell;
 Cell.Button = ButtonCell;
+Cell.Switch = SwitchCell;
 
 export { Cell, CellProps, CellGroupProps, NavigationCellProps, CellSwipeItemProps };

--- a/packages/components/src/components/Switch/Switch.tsx
+++ b/packages/components/src/components/Switch/Switch.tsx
@@ -10,7 +10,6 @@ export type SwitchProps = {
     color?: "primary" | "secondary" | "danger";
     active?: boolean;
     disabled?: boolean;
-    loading?: boolean;
 };
 
 const KNOB_SIZE = 20;
@@ -19,14 +18,7 @@ const HEIGHT = 60;
 
 export const Switch = forwardRef<View, SwitchProps & ViewProps>(
     (
-        {
-            color = "primary",
-            onChange = () => null,
-            active = false,
-            disabled = false,
-            loading = false,
-            ...rest
-        },
+        { color = "primary", onChange = () => null, active = false, disabled = false, ...rest },
         ref,
     ) => {
         const styles = useStyles(themeStyles, {
@@ -37,11 +29,7 @@ export const Switch = forwardRef<View, SwitchProps & ViewProps>(
 
         const token = useToken();
 
-        // WIDTH - KNOB_SIZE * 1.7
-
         const progressValue = useRef(new Animated.Value(active ? 1 : 0)).current;
-
-        // const backgroundProgressValue = useRef(new Animated.Value(0)).current;
 
         const activeKnobAnimation = Animated.timing(progressValue, {
             toValue: 1,
@@ -90,7 +78,7 @@ export const Switch = forwardRef<View, SwitchProps & ViewProps>(
 
         return (
             <PressableHighlight
-                disabled={disabled || loading}
+                disabled={disabled}
                 onPress={handlePress}
                 style={styles.pressableContainer}
             >


### PR DESCRIPTION
Added a new component `Cell.Switch` based on previous child cell components. It takes the same props as both switch and cell. 

Added `SwitchCellScreen` to display different prop usage and functionality. 

Added navigation for `SwitchCellScreen`.

Removed unused code from `Switch` component.