### PR TITLE
fix: `Cell` style issues...again

### DIFF
--- a/.changeset/modern-wolves-grin.md
+++ b/.changeset/modern-wolves-grin.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-components": patch
+---
+
+Fixed Cell styling issue in non-ScrollView containers... again

--- a/apps/chronicles/screens/components/CellScreen.tsx
+++ b/apps/chronicles/screens/components/CellScreen.tsx
@@ -59,18 +59,24 @@ export const CellScreen = () => {
             <View style={styles.readableContent}>
                 <Typography>
                     The clumping behavior applies for any type of cell. The group below contains
-                    three cells: one navigation cell, one normal blank cell and one custom cell made
-                    for this screen. You would typically create app specific cells for your apps
-                    needs.
+                    three cells: one switch cell, one navigation cell and one custom cell made for
+                    this screen. You would typically create app specific cells for your apps needs.
                 </Typography>
             </View>
             <Spacer />
             <Cell.Group>
-                <Cell.Navigation title="This is a navigation cell" onPress={() => null} />
-                <Cell>
-                    <Typography>This is a normal blank cell</Typography>
-                </Cell>
-                <MyCustomCell title="This is a custom cell" />
+                <Cell.Switch
+                    title="This cell is a switch cell"
+                    isActive={false}
+                    onChange={() => null}
+                />
+                <Cell.Navigation
+                    title="This is a navigation cell"
+                    description="And this is its description!"
+                    iconName="navigation-outline"
+                    onPress={() => null}
+                />
+                <MyCustomCell title="And this is a custom cell" />
             </Cell.Group>
             <Spacer />
             <View style={styles.readableContent}>
@@ -85,7 +91,7 @@ export const CellScreen = () => {
                 <Cell
                     leftAdornment={
                         <View style={styles.adornment}>
-                            <Typography> This is the left adornment</Typography>
+                            <Typography>This is the left adornment</Typography>
                         </View>
                     }
                 />
@@ -121,9 +127,7 @@ export const CellScreen = () => {
             </View>
             <Spacer />
             <Cell onPress={() => null}>
-                <View style={{ justifyContent: "center" }}>
-                    <Typography>This cell responds to touch!</Typography>
-                </View>
+                <Typography>This cell responds to touch!</Typography>
             </Cell>
             <Spacer />
             <View style={styles.readableContent}>
@@ -201,6 +205,7 @@ const themeStyles = EDSStyleSheet.create(theme => ({
         paddingHorizontal: theme.spacing.container.paddingHorizontal,
     },
     child: {
+        flex: 1,
         borderWidth: 2,
         justifyContent: "center",
         alignItems: "center",
@@ -209,7 +214,6 @@ const themeStyles = EDSStyleSheet.create(theme => ({
         borderRadius: theme.geometry.border.elementBorderRadius,
     },
     adornment: {
-        flex: 1,
         borderWidth: 2,
         justifyContent: "center",
         alignItems: "center",

--- a/packages/components/src/components/Cell/Cell.tsx
+++ b/packages/components/src/components/Cell/Cell.tsx
@@ -52,11 +52,11 @@ export const Cell = forwardRef<View, React.PropsWithChildren<CellProps>>(
 
         const CellContent = () => (
             <View {...rest} style={[styles.container, rest.style]} ref={ref}>
-                <PressableHighlight disabled={!onPress} onPress={onPress} style={{ flex: 1 }}>
+                <PressableHighlight disabled={!onPress} onPress={onPress}>
                     <View style={styles.contentContainer}>
-                        {leftAdornment && <View>{leftAdornment}</View>}
+                        {leftAdornment && <View style={styles.adornment}>{leftAdornment}</View>}
                         <View style={styles.children}>{children}</View>
-                        {rightAdornment && <View>{rightAdornment}</View>}
+                        {rightAdornment && <View style={styles.adornment}>{rightAdornment}</View>}
                     </View>
                     {!isLastCell && (
                         <View style={styles.dividerOuter}>
@@ -110,6 +110,10 @@ const themeStyle = EDSStyleSheet.create((theme, props: CellGroupContextType) => 
     },
     children: {
         flex: 1,
+        flexDirection: "row",
+    },
+    adornment: {
+        flexDirection: "row",
     },
     dividerOuter: {
         position: "absolute",

--- a/packages/components/src/components/Cell/NavigationCell.tsx
+++ b/packages/components/src/components/Cell/NavigationCell.tsx
@@ -42,13 +42,13 @@ export const NavigationCell = ({
     const styles = useStyles(themeStyles);
 
     const IconAdornment = () => (
-        <View style={styles.iconContainer}>
+        <View style={styles.adornmentContainer}>
             <Icon name={iconName ?? "dots-square"} color={disabled ? "textDisabled" : undefined} />
         </View>
     );
 
     const DisclosureAdornment = () => (
-        <View style={styles.disclosureContainer}>
+        <View style={styles.adornmentContainer}>
             <Icon name="chevron-right" color={disabled ? "textDisabled" : undefined} />
         </View>
     );
@@ -88,18 +88,10 @@ NavigationCell.displayName = "Cell.Navigation";
 
 const themeStyles = EDSStyleSheet.create(theme => ({
     contentContainer: {
-        flex: 1,
         justifyContent: "center",
         gap: theme.spacing.cell.content.titleDescriptionGap,
     },
-    iconContainer: {
-        flex: 1,
+    adornmentContainer: {
         justifyContent: "center",
-        alignItems: "center",
-    },
-    disclosureContainer: {
-        flex: 1,
-        justifyContent: "center",
-        alignItems: "center",
     },
 }));


### PR DESCRIPTION
- Removed flexing containers in `Cell` component
- Default inner containers of a `Cell` to `flexDirection: "row"`