### PR TITLE
fix: accordion item chevron not showing properly

### DIFF
--- a/.changeset/giant-wombats-cough.md
+++ b/.changeset/giant-wombats-cough.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-components": patch
+---
+
+Fixed an issue where accordion item chevron did not display properly

--- a/packages/components/src/components/Accordion/AccordionItem.tsx
+++ b/packages/components/src/components/Accordion/AccordionItem.tsx
@@ -166,9 +166,7 @@ const themeStyles = EDSStyleSheet.create((theme, props: AccordionContextType) =>
             paddingVertical: theme.spacing.container.paddingVertical,
         },
         iconContainer: {
-            flex: 1,
             justifyContent: "center",
-            alignItems: "center",
         },
         dividerOuter: {
             position: "absolute",

--- a/packages/components/src/components/Cell/ButtonCell.tsx
+++ b/packages/components/src/components/Cell/ButtonCell.tsx
@@ -89,13 +89,10 @@ ButtonCell.displayName = "Cell.Button";
 
 const themeStyles = EDSStyleSheet.create(theme => ({
     contentContainer: {
-        flex: 1,
         justifyContent: "center",
         gap: theme.spacing.cell.content.titleDescriptionGap,
     },
     iconContainer: {
-        flex: 1,
         justifyContent: "center",
-        alignItems: "center",
     },
 }));

--- a/packages/components/src/components/Cell/Cell.tsx
+++ b/packages/components/src/components/Cell/Cell.tsx
@@ -55,7 +55,9 @@ export const Cell = forwardRef<View, React.PropsWithChildren<CellProps>>(
                 <PressableHighlight disabled={!onPress} onPress={onPress}>
                     <View style={styles.contentContainer}>
                         {leftAdornment && <View style={styles.adornment}>{leftAdornment}</View>}
-                        <View style={styles.children}>{children}</View>
+                        <View style={styles.children}>
+                            <View style={{ flex: 1 }}>{children}</View>
+                        </View>
                         {rightAdornment && <View style={styles.adornment}>{rightAdornment}</View>}
                     </View>
                     {!isLastCell && (

--- a/packages/components/src/components/Cell/CellGroup.tsx
+++ b/packages/components/src/components/Cell/CellGroup.tsx
@@ -46,7 +46,7 @@ export const CellGroup = ({
                         {title}
                     </Typography>
                 )}
-                <View>{adornment}</View>
+                <View style={{ flex: 1 }}>{adornment}</View>
             </View>
             {Children.map(children, (child, index) => (
                 <CellGroupContext.Provider
@@ -67,7 +67,6 @@ const themeStyles = EDSStyleSheet.create(theme => ({
         paddingHorizontal: theme.spacing.container.paddingHorizontal,
         paddingBottom: theme.spacing.cell.group.titleBottomPadding,
         flexDirection: "row",
-        flex: 1,
         justifyContent: "space-between",
         alignItems: "flex-end",
     },

--- a/packages/components/src/components/Cell/SwitchCell.tsx
+++ b/packages/components/src/components/Cell/SwitchCell.tsx
@@ -92,8 +92,6 @@ const themeStyles = EDSStyleSheet.create(theme => ({
         gap: theme.spacing.cell.content.titleDescriptionGap,
     },
     iconContainer: {
-        flex: 1,
         justifyContent: "center",
-        alignItems: "center",
     },
 }));


### PR DESCRIPTION
- Add inner wrapper child view in `Cell` children container
- Remove flex misuse in `Cell.Button`, `Cell.Switch`, `Cell.Group` `Accordion.Item`