### PR TITLE
fix(iconbutton): Adjust pressable container size on icon button

### DIFF
--- a/.changeset/fuzzy-goats-admire.md
+++ b/.changeset/fuzzy-goats-admire.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-components": patch
+---
+
+Adjusted the pressable container around the icon button to its original size

--- a/packages/components/src/components/Button/IconButton.tsx
+++ b/packages/components/src/components/Button/IconButton.tsx
@@ -79,7 +79,7 @@ type IconButtonStyleSheetProps = {
 
 const themeStyles = EDSStyleSheet.create((theme, props: IconButtonStyleSheetProps) => {
     const { color, disabled, variant, iconSize } = props;
-    const pressableContainerSize = iconSize * 1.3;
+    const pressableContainerSize = iconSize * 1.8;
 
     let backgroundColor = theme.colors.interactive[color];
     let textColor =


### PR DESCRIPTION
Pressable container size was incorrect
- Changed the size on the pressable container around the icon button to it's correct size 