### PR TITLE
feat: add scopes prop to login button

### DIFF
--- a/.changeset/shaggy-berries-join.md
+++ b/.changeset/shaggy-berries-join.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-auth": patch
+---
+
+added scopes prop to the login button

--- a/apps/chronicles/package.json
+++ b/apps/chronicles/package.json
@@ -1,63 +1,63 @@
 {
-    "name": "@equinor/mad-chronicles",
-    "version": "1.1.1",
-    "scripts": {
-        "start": "expo start --dev-client",
-        "android": "expo run:android",
-        "dev": "expo run:ios",
-        "web": "expo start --web",
-        "build": "npx expo prebuild --platform ios",
-        "ios": "expo run:ios",
-        "lint": "eslint ."
-    },
-    "dependencies": {
-        "@equinor/mad-components": "workspace:*",
-        "@equinor/mad-insights": "workspace:*",
-        "@equinor/mad-navigation": "workspace:*",
-        "@equinor/react-native-skia-draw": "workspace:*",
-        "@equinor/mad-auth": "workspace:*",
-        "@expo/vector-icons": "^13.0.0",
-        "@expo/webpack-config": "^18.0.1",
-        "@react-navigation/bottom-tabs": "^6.0.5",
-        "@react-navigation/native": "^6.0.2",
-        "@react-navigation/native-stack": "^6.1.0",
-        "@shopify/react-native-skia": "0.1.196",
-        "expo": "~49.0.5",
-        "expo-asset": "~8.10.1",
-        "expo-constants": "~14.4.2",
-        "expo-font": "~11.4.0",
-        "expo-image-picker": "~14.3.2",
-        "expo-linking": "~5.0.2",
-        "expo-splash-screen": "~0.20.4",
-        "expo-status-bar": "~1.6.0",
-        "expo-system-ui": "~2.4.0",
-        "expo-web-browser": "~12.3.2",
-        "react": "18.2.0",
-        "react-dom": "18.2.0",
-        "react-native": "0.72.3",
-        "react-native-device-info": "^10.9.0",
-        "react-native-gesture-handler": "~2.12.0",
-        "react-native-reanimated": "~3.3.0",
-        "react-native-safe-area-context": "4.6.3",
-        "react-native-screens": "~3.22.1",
-        "react-native-svg": "13.9.0",
-        "react-native-web": "~0.19.7",
-        "react-native-msal": "git+https://github.com/equinor/react-native-msal.git#f1069d3b8f6ca911f60af1ddce45c8512bc58714",
-        "uuid": "^3.0.0"
-    },
-    "devDependencies": {
-        "@babel/core": "^7.21.4",
-        "@equinor/eslint-config-mad": "workspace:*",
-        "@types/react": "~18.2.16",
-        "@types/react-native": "~0.70.6",
-        "babel-loader": "^8.3.0",
-        "react-test-renderer": "18.1.0",
-        "typescript": "^5.1.3"
-    },
-    "private": true,
-    "workspaces": {
-        "nohoist": [
-            "uuid"
-        ]
-    }
+  "name": "@equinor/mad-chronicles",
+  "version": "1.1.1",
+  "scripts": {
+    "start": "expo start --dev-client",
+    "android": "expo run:android",
+    "dev": "expo run:ios",
+    "web": "expo start --web",
+    "build": "npx expo prebuild --platform ios",
+    "ios": "expo run:ios",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "@equinor/mad-components": "workspace:*",
+    "@equinor/mad-insights": "workspace:*",
+    "@equinor/mad-navigation": "workspace:*",
+    "@equinor/react-native-skia-draw": "workspace:*",
+    "@equinor/mad-auth": "workspace:*",
+    "@expo/vector-icons": "^13.0.0",
+    "@expo/webpack-config": "^18.0.1",
+    "@react-navigation/bottom-tabs": "^6.0.5",
+    "@react-navigation/native": "^6.0.2",
+    "@react-navigation/native-stack": "^6.1.0",
+    "@shopify/react-native-skia": "0.1.196",
+    "expo": "~49.0.5",
+    "expo-asset": "~8.10.1",
+    "expo-constants": "~14.4.2",
+    "expo-font": "~11.4.0",
+    "expo-image-picker": "~14.3.2",
+    "expo-linking": "~5.0.2",
+    "expo-splash-screen": "~0.20.4",
+    "expo-status-bar": "~1.6.0",
+    "expo-system-ui": "~2.4.0",
+    "expo-web-browser": "~12.3.2",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-native": "0.72.3",
+    "react-native-device-info": "^10.9.0",
+    "react-native-gesture-handler": "~2.12.0",
+    "react-native-reanimated": "~3.3.0",
+    "react-native-safe-area-context": "4.6.3",
+    "react-native-screens": "~3.22.1",
+    "react-native-svg": "13.9.0",
+    "react-native-web": "~0.19.7",
+    "react-native-msal": "git+https://github.com/equinor/react-native-msal.git#f1069d3b8f6ca911f60af1ddce45c8512bc58714",
+    "uuid": "^3.0.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.21.4",
+    "@equinor/eslint-config-mad": "workspace:*",
+    "@types/react": "~18.2.16",
+    "@types/react-native": "~0.70.6",
+    "babel-loader": "^8.3.0",
+    "react-test-renderer": "18.1.0",
+    "typescript": "^5.1.3"
+  },
+  "private": true,
+  "workspaces": {
+    "nohoist": [
+      "uuid"
+    ]
+  }
 }

--- a/apps/chronicles/screens/LoginScreen.tsx
+++ b/apps/chronicles/screens/LoginScreen.tsx
@@ -18,6 +18,7 @@ export const LoginScreen = () => {
             <LoginButton
                 redirectUri="msauth.com.equinor.mad.chronicles://auth"
                 clientId="49222fe1-4e0a-4310-9e81-1a2c3eb9b2ed"
+                scopes={["0a429637-3fe1-4452-bd95-c87923ba340b/user_impersonation"]}
                 onAuthenticationSuccessful={() => navigation.navigate("Root")}
                 enableAutomaticAuthentication
             />

--- a/packages/auth/src/components/LoginButton.tsx
+++ b/packages/auth/src/components/LoginButton.tsx
@@ -7,6 +7,7 @@ export type LoginButtonProps = Omit<ButtonProps, "onPress" | "loading" | "disabl
     redirectUri: string;
     onAuthenticationSuccessful: () => void;
     title?: ButtonProps["title"];
+    scopes?: string[];
     enableAutomaticAuthentication?: boolean;
 };
 export const LoginButton = ({
@@ -14,6 +15,7 @@ export const LoginButton = ({
     redirectUri,
     onAuthenticationSuccessful,
     enableAutomaticAuthentication,
+    scopes = [],
     title = "Log in",
     ...rest
 }: LoginButtonProps) => {
@@ -22,6 +24,7 @@ export const LoginButton = ({
             clientId,
             redirectUri,
             onAuthenticationSuccessful,
+            scopes,
             enableAutomaticAuthentication,
         });
 

--- a/packages/auth/src/hooks/useAuthenticate.ts
+++ b/packages/auth/src/hooks/useAuthenticate.ts
@@ -11,6 +11,7 @@ export type UseAuthenticateProps = {
     onAuthenticationSuccessful: (res: MadAuthenticationResult) => void;
     redirectUri: string;
     clientId: string;
+    scopes: string[];
     enableAutomaticAuthentication?: boolean;
 };
 
@@ -28,6 +29,7 @@ export const useAuthenticate = ({
     onAuthenticationSuccessful,
     clientId,
     redirectUri,
+    scopes,
     enableAutomaticAuthentication,
 }: UseAuthenticateProps): UseAuthenticateResult => {
     const [authenticationInProgress, setAuthenticationInProgress] = useState(false);
@@ -53,7 +55,7 @@ export const useAuthenticate = ({
             });
             if (authenticationClientExists()) setAuthenticationClientInitialized(true);
             if (enableAutomaticAuthentication)
-                withAuthenticationPromiseHandler(authenticateSilently([]));
+                withAuthenticationPromiseHandler(authenticateSilently(scopes));
         };
 
         initiateClientAndMaybeAuthenticateSilently();
@@ -62,7 +64,7 @@ export const useAuthenticate = ({
 
     return {
         authenticationInProgress,
-        authenticate: () => withAuthenticationPromiseHandler(authenticateInteractively([])),
+        authenticate: () => withAuthenticationPromiseHandler(authenticateInteractively(scopes)),
         authenticationClientInitialized:
             authenticationClientExists() && authenticationClientInitialized,
     };


### PR DESCRIPTION
Dont know if this will help with our login issues, but it shouldn't make things worse!

I've sent an admin request consent for mad api prod, so we will have to check on monday if it makes things better.

This feature adds the ability to add scopes to the loginbutton. If you don't use the new prop, the scopes will be an empty array by default