### PR TITLE
chore: fix PR validation

### DIFF
--- a/apps/chronicles/package.json
+++ b/apps/chronicles/package.json
@@ -1,63 +1,63 @@
 {
-  "name": "@equinor/mad-chronicles",
-  "version": "1.1.1",
-  "scripts": {
-    "start": "expo start --dev-client",
-    "android": "expo run:android",
-    "dev": "expo run:ios",
-    "web": "expo start --web",
-    "build": "npx expo prebuild --platform ios",
-    "ios": "expo run:ios",
-    "lint": "eslint . && tsc --noEmit"
-  },
-  "dependencies": {
-    "@equinor/mad-components": "workspace:*",
-    "@equinor/mad-insights": "workspace:*",
-    "@equinor/mad-navigation": "workspace:*",
-    "@equinor/react-native-skia-draw": "workspace:*",
-    "@equinor/mad-auth": "workspace:*",
-    "@expo/vector-icons": "^13.0.0",
-    "@expo/webpack-config": "^18.0.1",
-    "@react-navigation/bottom-tabs": "^6.0.5",
-    "@react-navigation/native": "^6.0.2",
-    "@react-navigation/native-stack": "^6.1.0",
-    "@shopify/react-native-skia": "0.1.196",
-    "expo": "~49.0.5",
-    "expo-asset": "~8.10.1",
-    "expo-constants": "~14.4.2",
-    "expo-font": "~11.4.0",
-    "expo-image-picker": "~14.3.2",
-    "expo-linking": "~5.0.2",
-    "expo-splash-screen": "~0.20.4",
-    "expo-status-bar": "~1.6.0",
-    "expo-system-ui": "~2.4.0",
-    "expo-web-browser": "~12.3.2",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "react-native": "0.72.3",
-    "react-native-device-info": "^10.9.0",
-    "react-native-gesture-handler": "~2.12.0",
-    "react-native-reanimated": "~3.3.0",
-    "react-native-safe-area-context": "4.6.3",
-    "react-native-screens": "~3.22.1",
-    "react-native-svg": "13.9.0",
-    "react-native-web": "~0.19.7",
-    "react-native-msal": "git+https://github.com/equinor/react-native-msal.git#f1069d3b8f6ca911f60af1ddce45c8512bc58714",
-    "uuid": "^3.0.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.21.4",
-    "@equinor/eslint-config-mad": "workspace:*",
-    "@types/react": "~18.2.16",
-    "@types/react-native": "~0.70.6",
-    "babel-loader": "^8.3.0",
-    "react-test-renderer": "18.1.0",
-    "typescript": "^5.1.3"
-  },
-  "private": true,
-  "workspaces": {
-    "nohoist": [
-      "uuid"
-    ]
-  }
+    "name": "@equinor/mad-chronicles",
+    "version": "1.1.1",
+    "scripts": {
+        "start": "expo start --dev-client",
+        "android": "expo run:android",
+        "dev": "expo run:ios",
+        "web": "expo start --web",
+        "build": "npx expo prebuild --platform ios",
+        "ios": "expo run:ios",
+        "lint": "tsc --noEmit && eslint ."
+    },
+    "dependencies": {
+        "@equinor/mad-components": "workspace:*",
+        "@equinor/mad-insights": "workspace:*",
+        "@equinor/mad-navigation": "workspace:*",
+        "@equinor/react-native-skia-draw": "workspace:*",
+        "@equinor/mad-auth": "workspace:*",
+        "@expo/vector-icons": "^13.0.0",
+        "@expo/webpack-config": "^18.0.1",
+        "@react-navigation/bottom-tabs": "^6.0.5",
+        "@react-navigation/native": "^6.0.2",
+        "@react-navigation/native-stack": "^6.1.0",
+        "@shopify/react-native-skia": "0.1.196",
+        "expo": "~49.0.5",
+        "expo-asset": "~8.10.1",
+        "expo-constants": "~14.4.2",
+        "expo-font": "~11.4.0",
+        "expo-image-picker": "~14.3.2",
+        "expo-linking": "~5.0.2",
+        "expo-splash-screen": "~0.20.4",
+        "expo-status-bar": "~1.6.0",
+        "expo-system-ui": "~2.4.0",
+        "expo-web-browser": "~12.3.2",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
+        "react-native": "0.72.3",
+        "react-native-device-info": "^10.9.0",
+        "react-native-gesture-handler": "~2.12.0",
+        "react-native-reanimated": "~3.3.0",
+        "react-native-safe-area-context": "4.6.3",
+        "react-native-screens": "~3.22.1",
+        "react-native-svg": "13.9.0",
+        "react-native-web": "~0.19.7",
+        "react-native-msal": "git+https://github.com/equinor/react-native-msal.git#f1069d3b8f6ca911f60af1ddce45c8512bc58714",
+        "uuid": "^3.0.0"
+    },
+    "devDependencies": {
+        "@babel/core": "^7.21.4",
+        "@equinor/eslint-config-mad": "workspace:*",
+        "@types/react": "~18.2.16",
+        "@types/react-native": "~0.70.6",
+        "babel-loader": "^8.3.0",
+        "react-test-renderer": "18.1.0",
+        "typescript": "^5.1.3"
+    },
+    "private": true,
+    "workspaces": {
+        "nohoist": [
+            "uuid"
+        ]
+    }
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -4,7 +4,7 @@
     "description": "A simple wrapper library for react-native-msal",
     "type": "module",
     "scripts": {
-        "build": "tsup-node",
+        "build": "tsup-node && echo '\n ⚙️ Generating typescript declarations..' && tsc --project tsconfig.json --emitDeclarationOnly --declaration",
         "test": "jest",
         "dev": "tsup-node --watch --clean=false",
         "lint": "eslint src/"

--- a/packages/auth/tsup.config.ts
+++ b/packages/auth/tsup.config.ts
@@ -1,10 +1,21 @@
+import { spawnSync } from "child_process";
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig(options => ({
     entry: ["./src/**/*.ts?(x)", "!./src/types.d.ts", "!./src/__tests__/*"],
     splitting: true,
     clean: true,
-    dts: true,
+    dts: false,
     format: "esm",
+    bundle: !options.watch,
     tsconfig: "./tsconfig.json",
-});
+    async onSuccess() {
+        // In watch mode we will build using this function.
+        // If not in watch mode, we run tsc separately
+        // to make sure PR validation works
+        if (!options.watch) return;
+        // eslint-disable-next-line no-console
+        console.log("⚙️ Generating typescript declarations..");
+        spawnSync("tsc", ["--project", "tsconfig.json", "--emitDeclarationOnly", "--declaration"]);
+    },
+}));

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "build": "tsup-node && echo '\n ⚙️ Generating typescript declarations..' && tsc --project tsconfig.json --emitDeclarationOnly --declaration",
         "test": "jest",
-        "dev": "tsup-node --watch --clean=false && echo '\n ⚙️ Generating typescript declarations..' && tsc --project tsconfig.json --emitDeclarationOnly --declaration",
+        "dev": "tsup-node --watch --clean=false",
         "lint": "eslint src/"
     },
     "keywords": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -4,9 +4,9 @@
     "description": "A React Native component library implementing the Equinor Design System.",
     "type": "module",
     "scripts": {
-        "build": "tsup-node",
+        "build": "tsup-node && echo '\n ⚙️ Generating typescript declarations..' && tsc --project tsconfig.json --emitDeclarationOnly --declaration",
         "test": "jest",
-        "dev": "tsup-node --watch --clean=false",
+        "dev": "tsup-node --watch --clean=false && echo '\n ⚙️ Generating typescript declarations..' && tsc --project tsconfig.json --emitDeclarationOnly --declaration",
         "lint": "eslint src/"
     },
     "keywords": [

--- a/packages/components/src/utils/getBackgroundColorForButton.ts
+++ b/packages/components/src/utils/getBackgroundColorForButton.ts
@@ -18,7 +18,7 @@ export const getBackgroundColorForButton = (
     variant: Variant,
     color: ButtonColorVariant,
     disabled: boolean,
-): number => {
+) => {
     if (variant !== "contained") return "transparent";
     if (disabled) return theme.colors.interactive.disabled;
     return theme.colors.interactive[color];

--- a/packages/components/src/utils/getBackgroundColorForButton.ts
+++ b/packages/components/src/utils/getBackgroundColorForButton.ts
@@ -18,7 +18,7 @@ export const getBackgroundColorForButton = (
     variant: Variant,
     color: ButtonColorVariant,
     disabled: boolean,
-) => {
+): number => {
     if (variant !== "contained") return "transparent";
     if (disabled) return theme.colors.interactive.disabled;
     return theme.colors.interactive[color];

--- a/packages/components/tsup.config.ts
+++ b/packages/components/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig(options => ({
     entry: ["./src/**/*.ts?(x)", "!./src/types.d.ts", "!./src/__tests__/*"],
     splitting: true,
     clean: true,
-    dts: true,
+    dts: false,
     format: "esm",
     bundle: !options.watch,
     tsconfig: "./tsconfig.json",

--- a/packages/components/tsup.config.ts
+++ b/packages/components/tsup.config.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "child_process";
 import { defineConfig } from "tsup";
 
 export default defineConfig(options => ({
@@ -13,5 +14,14 @@ export default defineConfig(options => ({
     },
     esbuildOptions(options) {
         options.assetNames = "assets/fonts/[name]";
+    },
+    async onSuccess() {
+        // In watch mode we will build using this function.
+        // If not in watch mode, we run tsc separately
+        // to make sure PR validation works
+        if (!options.watch) return;
+        // eslint-disable-next-line no-console
+        console.log("⚙️ Generating typescript declarations..");
+        spawnSync("tsc", ["--project", "tsconfig.json", "--emitDeclarationOnly", "--declaration"]);
     },
 }));

--- a/packages/insights/package.json
+++ b/packages/insights/package.json
@@ -4,7 +4,7 @@
     "description": "Application Insights implementation for the mad team",
     "type": "module",
     "scripts": {
-        "build": "tsup-node",
+        "build": "tsup-node && echo '\n ⚙️ Generating typescript declarations..' && tsc --project tsconfig.json --emitDeclarationOnly --declaration",
         "test": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js",
         "dev": "tsup-node --watch --clean=false",
         "lint": "eslint src/"

--- a/packages/insights/tsup.config.ts
+++ b/packages/insights/tsup.config.ts
@@ -1,10 +1,21 @@
+import { spawnSync } from "child_process";
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig(options => ({
     entry: ["./src/**/*.ts?(x)", "!./src/types.d.ts", "!./src/__tests__/*"],
     splitting: true,
     clean: true,
-    dts: true,
+    dts: false,
     format: "esm",
+    bundle: !options.watch,
     tsconfig: "./tsconfig.json",
-});
+    async onSuccess() {
+        // In watch mode we will build using this function.
+        // If not in watch mode, we run tsc separately
+        // to make sure PR validation works
+        if (!options.watch) return;
+        // eslint-disable-next-line no-console
+        console.log("⚙️ Generating typescript declarations..");
+        spawnSync("tsc", ["--project", "tsconfig.json", "--emitDeclarationOnly", "--declaration"]);
+    },
+}));

--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -4,7 +4,7 @@
     "description": "Navigation package built on top of React Navigation",
     "type": "module",
     "scripts": {
-        "build": "tsup-node",
+        "build": "tsup-node && echo '\n ⚙️ Generating typescript declarations..' && tsc --project tsconfig.json --emitDeclarationOnly --declaration",
         "test": "jest",
         "dev": "tsup-node --watch --clean=false",
         "lint": "eslint src/"

--- a/packages/navigation/tsup.config.ts
+++ b/packages/navigation/tsup.config.ts
@@ -1,10 +1,21 @@
+import { spawnSync } from "child_process";
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig(options => ({
     entry: ["./src/**/*.ts?(x)", "!./src/types.d.ts", "!./src/__tests__/*"],
     splitting: true,
     clean: true,
-    dts: true,
+    dts: false,
     format: "esm",
+    bundle: !options.watch,
     tsconfig: "./tsconfig.json",
-});
+    async onSuccess() {
+        // In watch mode we will build using this function.
+        // If not in watch mode, we run tsc separately
+        // to make sure PR validation works
+        if (!options.watch) return;
+        // eslint-disable-next-line no-console
+        console.log("⚙️ Generating typescript declarations..");
+        spawnSync("tsc", ["--project", "tsconfig.json", "--emitDeclarationOnly", "--declaration"]);
+    },
+}));

--- a/packages/skia-draw/package.json
+++ b/packages/skia-draw/package.json
@@ -4,7 +4,7 @@
     "description": "A React Native drawing library running on SKIA",
     "type": "module",
     "scripts": {
-        "build": "tsup-node",
+        "build": "tsup-node && echo '\n ⚙️ Generating typescript declarations..' && tsc --project tsconfig.json --emitDeclarationOnly --declaration",
         "dev": "tsup-node --watch --clean=false",
         "lint": "eslint src/"
     },

--- a/packages/skia-draw/tsup.config.ts
+++ b/packages/skia-draw/tsup.config.ts
@@ -1,10 +1,21 @@
+import { spawnSync } from "child_process";
 import { defineConfig } from "tsup";
 
-export default defineConfig({
-    entry: ["./src/**/*.ts?(x)", "!./src/__tests__/*"],
+export default defineConfig(options => ({
+    entry: ["./src/**/*.ts?(x)", "!./src/types.d.ts", "!./src/__tests__/*"],
     splitting: true,
     clean: true,
-    dts: true,
+    dts: false,
     format: "esm",
+    bundle: !options.watch,
     tsconfig: "./tsconfig.json",
-});
+    async onSuccess() {
+        // In watch mode we will build using this function.
+        // If not in watch mode, we run tsc separately
+        // to make sure PR validation works
+        if (!options.watch) return;
+        // eslint-disable-next-line no-console
+        console.log("⚙️ Generating typescript declarations..");
+        spawnSync("tsc", ["--project", "tsconfig.json", "--emitDeclarationOnly", "--declaration"]);
+    },
+}));


### PR DESCRIPTION
Fixed by changing back to tsc for compiling declaration files.
- In watch mode, we run `tsc` as part of tsup, in the onSuccess function
- When we run `build` (which is not in watch mode), we run tsc after tsup is finished, to make sure the step throws an error if it fails