### PR TITLE
fix: add JSX Elements to child props of Typography

### DIFF
--- a/.changeset/wicked-carrots-kick.md
+++ b/.changeset/wicked-carrots-kick.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-components": patch
+---
+
+Changed type of Typography child props to include JSX elements

--- a/packages/components/src/components/Typography/Typography.tsx
+++ b/packages/components/src/components/Typography/Typography.tsx
@@ -48,7 +48,13 @@ export type TypographyProps<TGroup extends TypographyGroup = "basic"> = {
 } & TextProps;
 
 export type TextChildren = {
-    children: string | string[] | number | undefined | null;
+    children:
+        | string
+        | number
+        | null
+        | undefined
+        | React.JSX.Element
+        | (string | string[] | number | null | undefined | React.JSX.Element)[];
 };
 
 const TypographyInner = <TGroup extends TypographyGroup>({


### PR DESCRIPTION
Adds support for nesting Typography components and other JSX elements. Tested it a bit in Code of Conduct and seems to handle most props with ease (e.g. View, TouchableOpacity etc.)