### PR TITLE
fix(button): pass `style` prop to outermost component

### DIFF
--- a/.changeset/thick-fireants-melt.md
+++ b/.changeset/thick-fireants-melt.md
@@ -1,0 +1,7 @@
+---
+"@equinor/mad-components": patch
+---
+
+`Button`: The `style` prop is now passed to the outermost component to make it behave as expected.
+We now export `ButtonSpecificProps` which was previously named `ButtonProps`. `ButtonProps` is still
+exported and consists of the types `ButtonSpecificProps` and `ViewProps`.

--- a/packages/components/src/components/Button/Button.tsx
+++ b/packages/components/src/components/Button/Button.tsx
@@ -10,7 +10,7 @@ import { Icon, IconName } from "../Icon";
 import { DotProgress } from "../ProgressIndicator";
 import { getBackgroundColorForButton } from "../../utils/getBackgroundColorForButton";
 
-export type ButtonProps = {
+export type ButtonSpecificProps = {
     /**
      * Label text of the button.
      */
@@ -45,7 +45,9 @@ export type ButtonProps = {
     iconPosition?: "leading" | "trailing";
 };
 
-export const Button = forwardRef<View, ButtonProps & ViewProps>(
+export type ButtonProps = ButtonSpecificProps & ViewProps;
+
+export const Button = forwardRef<View, ButtonProps>(
     (
         {
             title,
@@ -88,27 +90,25 @@ export const Button = forwardRef<View, ButtonProps & ViewProps>(
         );
 
         return (
-            <View>
-                <View ref={ref} style={[styles.colorContainer, rest.style]}>
-                    <PressableHighlight
-                        disabled={disabled}
-                        onPress={isToggleButton ? toggleData.toggle : onPress}
-                        style={styles.pressableContainer}
-                    >
-                        <View style={styles.labelContainer}>
-                            {loading ? (
-                                <DotProgress
-                                    color={
-                                        disabled || variant !== "contained" ? "primary" : "neutral"
-                                    }
-                                    size={12}
-                                />
-                            ) : (
-                                ButtonContent()
-                            )}
-                        </View>
-                    </PressableHighlight>
-                </View>
+            <View ref={ref} style={[styles.colorContainer, rest.style]}>
+                <PressableHighlight
+                    disabled={disabled}
+                    onPress={isToggleButton ? toggleData.toggle : onPress}
+                    style={styles.pressableContainer}
+                >
+                    <View style={styles.labelContainer}>
+                        {loading ? (
+                            <DotProgress
+                                color={
+                                    disabled || variant !== "contained" ? "primary" : "neutral"
+                                }
+                                size={12}
+                            />
+                        ) : (
+                            ButtonContent()
+                        )}
+                    </View>
+                </PressableHighlight>
             </View>
         );
     },

--- a/packages/components/src/components/Button/index.ts
+++ b/packages/components/src/components/Button/index.ts
@@ -1,4 +1,4 @@
-import { Button as _Button, ButtonProps } from "./Button";
+import { Button as _Button, ButtonProps, ButtonSpecificProps } from "./Button";
 import { ButtonGroup, ButtonGroupProps } from "./ButtonGroup";
 import { ToggleButton, ToggleButtonProps } from "./ToggleButton";
 import { IconButton, IconButtonProps } from "./IconButton";
@@ -23,4 +23,4 @@ Button.Group = ButtonGroup;
 Button.Toggle = ToggleButton;
 Button.Icon = IconButton;
 
-export { Button, ButtonProps, ButtonGroupProps, ToggleButtonProps, IconButtonProps };
+export { Button, ButtonProps, ButtonSpecificProps, ButtonGroupProps, ToggleButtonProps, IconButtonProps };


### PR DESCRIPTION
- Remove wrapper `View` to make the `style` prop on `Button` behave as expected.
- Add `ButtonSpecificProps` type which has the same types as `ButtonProps` had.
- Update `ButtonProps` type to be `ButtonSpecificProps`  and `ViewProps`.

Closes #170