### PR TITLE
perf: load `MaterialCommunityIcons` font in `useEDS`

### DIFF
--- a/.changeset/healthy-nails-unite.md
+++ b/.changeset/healthy-nails-unite.md
@@ -1,0 +1,7 @@
+---
+"@equinor/mad-components": patch
+---
+
+`useEDS`: Added `MaterialCommunityIcons` to the list of loaded fonts since our icons use it. This
+means that you no longer need to specifically load `MaterialCommunityIcons` in your project, often
+found in `useCachedResources`.

--- a/apps/chronicles/hooks/useCachedResources.ts
+++ b/apps/chronicles/hooks/useCachedResources.ts
@@ -1,5 +1,3 @@
-import { FontAwesome } from "@expo/vector-icons";
-import * as Font from "expo-font";
 import * as SplashScreen from "expo-splash-screen";
 import { useEffect, useState } from "react";
 
@@ -11,11 +9,6 @@ export default function useCachedResources() {
         async function loadResourcesAndDataAsync() {
             try {
                 SplashScreen.preventAutoHideAsync();
-
-                // Load fonts
-                await Font.loadAsync({
-                    ...FontAwesome.font,
-                });
             } catch (e) {
                 // We might want to provide this error information to an error reporting service
                 console.warn(e);

--- a/packages/components/src/hooks/useEDS.ts
+++ b/packages/components/src/hooks/useEDS.ts
@@ -8,8 +8,10 @@ import EquinorLightItalic from "../assets/fonts/Equinor-LightItalic.otf";
 import EquinorMedium from "../assets/fonts/Equinor-Medium.otf";
 import EquinorMediumItalic from "../assets/fonts/Equinor-MediumItalic.otf";
 import EquinorRegular from "../assets/fonts/Equinor-Regular.otf";
+import { MaterialCommunityIcons } from "@expo/vector-icons";
 
 const fontMap = {
+    ...MaterialCommunityIcons.font,
     "Equinor-Bold": EquinorBold,
     "Equinor-BoldItalic": EquinorBoldItalic,
     "Equinor-Italic": EquinorItalic,


### PR DESCRIPTION
- Stop loading unused font in chronicles.
- Start loading `MaterialCommunityIcons` in `useEDS`.

Closes #277