### PR TITLE
fix(components): `LinearProgress` takes up too much vertical space

### DIFF
--- a/.changeset/afraid-crabs-camp.md
+++ b/.changeset/afraid-crabs-camp.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-components": patch
+---
+
+Fixed flexing issue in `LinearProgress`

--- a/packages/components/src/components/ProgressIndicator/LinearProgress.tsx
+++ b/packages/components/src/components/ProgressIndicator/LinearProgress.tsx
@@ -29,7 +29,7 @@ export const LinearProgress = ({ value, ...rest }: LinearProgressProps) => {
     });
 
     return (
-        <View style={[{ flex: 1, borderRadius: STROKE_WIDTH / 2, overflow: "hidden" }, rest.style]}>
+        <View style={[{ borderRadius: STROKE_WIDTH / 2, overflow: "hidden" }, rest.style]}>
             <Svg height={STROKE_WIDTH} width="100%">
                 <Rect
                     x="0"


### PR DESCRIPTION
- Remove `flex: 1`

Closes #286