### PR TITLE
feat!: add `readOnly` prop to `Input` component

### DIFF
--- a/.changeset/lovely-parents-work.md
+++ b/.changeset/lovely-parents-work.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-components": patch
+---
+
+Fixed `Input` component cyclic reference warnings

--- a/.changeset/two-ads-obey.md
+++ b/.changeset/two-ads-obey.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-components": minor
+---
+
+**Breaking change:** Removed `disabled` prop on `Input`. Replaced by `readOnly`

--- a/apps/chronicles/screens/components/ComponentScreen.tsx
+++ b/apps/chronicles/screens/components/ComponentScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { RouteProp } from "@react-navigation/native";
 import { ComponentsStackParamList } from "../../types/navigation";
-import { ComponentConfig, ComponentName } from "../../types/components";
+import { ComponentConfig } from "../../types/components";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { Button } from "@equinor/mad-components";
 

--- a/apps/chronicles/screens/components/components/InputScreen.tsx
+++ b/apps/chronicles/screens/components/components/InputScreen.tsx
@@ -58,8 +58,19 @@ export const InputScreen = () => {
                     }
                     placeholder="Anything goes here"
                 ></Input>
+
                 <Spacer />
                 <Typography>These come in different variants</Typography>
+                <Spacer />
+                <Input readOnly value={"This content is readonly"} />
+                <Spacer />
+                <Input
+                    readOnly
+                    multiline
+                    value={
+                        "This content is readonly and multiline so that you can select text from it!"
+                    }
+                />
                 <Spacer />
                 <Input placeholder="Placeholder danger" variant="danger" />
                 <Spacer />

--- a/apps/chronicles/settings.ts
+++ b/apps/chronicles/settings.ts
@@ -1,9 +1,8 @@
-import appJson from "./app.json"
-import { Platform } from "react-native"
+import appJson from "./app.json";
+import { Platform } from "react-native";
 
 export const getBuildNumber = (): string => {
-    const buildNumber = Platform.OS == "ios" ?
-        appJson.expo.ios.buildNumber as string :
-        appJson.expo.web.buildNumber as string;
+    const buildNumber =
+        Platform.OS == "ios" ? appJson.expo.ios.buildNumber : appJson.expo.web.buildNumber;
     return buildNumber;
-}
+};

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     },
     "devDependencies": {
         "@changesets/cli": "^2.26.0",
-        "@equinor/eslint-config-mad": "workspace:*",
         "@types/jest": "^26.0.14",
         "@types/node": "^18.13.0",
         "@typescript-eslint/eslint-plugin": "^6.13.2",

--- a/packages/components/.eslintrc.cjs
+++ b/packages/components/.eslintrc.cjs
@@ -5,4 +5,15 @@ module.exports = {
         project: ["./tsconfig.json"],
         tsconfigRootDir: __dirname,
     },
+    settings: {
+        "import/parsers": {
+            "@typescript-eslint/parser": [".ts", ".tsx"],
+        },
+        "import/resolver": {
+            typescript: {
+                alwaysTryTypes: true,
+                project: ["packages/*/tsconfig.json"],
+            },
+        },
+    },
 };

--- a/packages/components/.eslintrc.cjs
+++ b/packages/components/.eslintrc.cjs
@@ -12,7 +12,7 @@ module.exports = {
         "import/resolver": {
             typescript: {
                 alwaysTryTypes: true,
-                project: ["packages/*/tsconfig.json"],
+                project: ["packages/*/tsconfig.json", "./tsconfig.json"],
             },
         },
     },

--- a/packages/components/src/components/Dialog/service/DialogServiceProvider.tsx
+++ b/packages/components/src/components/Dialog/service/DialogServiceProvider.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Button } from "../../Button";
 import { Typography } from "../../Typography";
-import { Dialog } from "../index";
+import { Dialog } from "../Dialog";
 import { DialogHeader } from "../DialogHeader";
 import { DialogActions } from "../DialogActions";
 import { DialogCustomContent } from "../DialogCustomContent";

--- a/packages/components/src/components/EDSProvider/EDSProvider.tsx
+++ b/packages/components/src/components/EDSProvider/EDSProvider.tsx
@@ -1,10 +1,9 @@
 import React, { createContext, PropsWithChildren } from "react";
 import { ColorScheme, Density } from "../../styling/types";
-import { PortalProvider } from "../Portal/PortalContext";
-import { Portal } from "../Portal";
-import { DialogServiceProvider } from "../Dialog/service/DialogServiceProvider";
+import { Portal, PortalProvider } from "@/components/Portal";
+import { DialogServiceProvider } from "@/components/Dialog";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
-import { ScrimProvider } from "../_internal/ScrimProvider";
+import { ScrimProvider } from "@/components/_internal/ScrimProvider";
 
 export type EDSProviderProps = {
     /**

--- a/packages/components/src/components/Input/Input.tsx
+++ b/packages/components/src/components/Input/Input.tsx
@@ -7,7 +7,7 @@ import {
     View,
     Platform,
 } from "react-native";
-import { useStyles } from "../..";
+import { useStyles } from "@/hooks/useStyles";
 import { themeStyles } from "./InputStyle";
 
 export type InputProps = {

--- a/packages/components/src/components/Input/Input.tsx
+++ b/packages/components/src/components/Input/Input.tsx
@@ -5,10 +5,10 @@ import {
     TextInputProps,
     TextInputFocusEventData,
     View,
-    ViewStyle,
+    Platform,
 } from "react-native";
 import { useStyles } from "../..";
-import { EDSStyleSheet } from "../../styling";
+import { themeStyles } from "./InputStyle";
 
 export type InputProps = {
     /**
@@ -25,11 +25,6 @@ export type InputProps = {
      */
     placeholder?: string;
     /**
-     * A boolean value indicating whether or not the input component is disabled or not.
-     * Disabling the input causes it to not allow for any changes.
-     */
-    disabled?: boolean;
-    /**
      * A component that will be added to the left of the input field.
      */
     leftAdornments?: ReactNode;
@@ -41,25 +36,28 @@ export type InputProps = {
      * A variant to use for the validation of the input field.
      */
     variant?: "danger" | "warning" | "success";
-} & Omit<TextInputProps, "onChange" | "onChangeText">;
+    /**
+     * Whether or not the text should be editable.
+     */
+    readOnly?: boolean;
+} & Omit<TextInputProps, "onChange" | "onChangeText" | "readOnly">;
 
 export const Input = forwardRef<TextInput, InputProps>(
     (
         {
             leftAdornments,
             rightAdornments,
-            value,
             placeholder,
             onChange,
             multiline = false,
-            disabled = false,
             variant,
+            readOnly = false,
             ...rest
         },
         ref,
     ) => {
         const [isSelected, setIsSelected] = useState<boolean>(false);
-        const styles = useStyles(themedStyles, { multiline, isSelected, variant });
+        const styles = useStyles(themeStyles, { multiline, isSelected, variant, readOnly });
 
         const onFocus = (e: NativeSyntheticEvent<TextInputFocusEventData>) => {
             setIsSelected(true);
@@ -78,15 +76,19 @@ export const Input = forwardRef<TextInput, InputProps>(
                     {...rest}
                     ref={ref}
                     multiline={multiline}
-                    editable={!disabled}
-                    value={value}
+                    editable={!readOnly}
                     placeholder={placeholder}
                     onChangeText={onChange}
                     textAlignVertical="top"
                     placeholderTextColor={styles.placeholder.color}
                     onFocus={onFocus}
                     onBlur={onBlur}
-                    style={[styles.textInput, rest.style]}
+                    style={[
+                        styles.textInput,
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- this is appearanly available for web, but react native does not seem to recognize it
+                        Platform.OS === "web" ? ({ outline: "none" } as any) : {},
+                        rest.style,
+                    ]}
                 />
                 {rightAdornments}
             </View>
@@ -95,76 +97,3 @@ export const Input = forwardRef<TextInput, InputProps>(
 );
 
 Input.displayName = "Input";
-
-const themedStyles = EDSStyleSheet.create(
-    (
-        theme,
-        props: {
-            multiline: boolean;
-            isSelected: boolean;
-            variant?: "danger" | "warning" | "success";
-        },
-    ) => {
-        const { multiline, isSelected, variant } = props;
-        let borderStyle: ViewStyle;
-
-        switch (variant) {
-            case "danger":
-                borderStyle = {
-                    borderColor: theme.colors.feedback.danger,
-                    borderWidth: theme.geometry.border.focusedBorderWidth,
-                };
-                break;
-            case "warning":
-                borderStyle = {
-                    borderColor: theme.colors.feedback.warning,
-                    borderWidth: theme.geometry.border.focusedBorderWidth,
-                };
-                break;
-            case "success":
-                borderStyle = {
-                    borderColor: theme.colors.feedback.success,
-                    borderWidth: theme.geometry.border.focusedBorderWidth,
-                };
-                break;
-            default:
-                if (isSelected) {
-                    borderStyle = {
-                        borderColor: theme.colors.interactive.primary,
-                        borderWidth: theme.geometry.border.focusedBorderWidth,
-                    };
-                } else {
-                    borderStyle = {
-                        borderBottomColor: theme.colors.text.tertiary,
-                        borderBottomWidth: theme.geometry.border.focusedBorderWidth,
-                        borderColor: "transparent",
-                        borderWidth: theme.geometry.border.focusedBorderWidth,
-                    };
-                }
-        }
-
-        return {
-            contentContainer: {
-                flexDirection: "row",
-                backgroundColor: theme.colors.container.background,
-                ...borderStyle,
-            },
-            label: {
-                paddingHorizontal: theme.spacing.textField.paddingHorizontal,
-            },
-            textInput: {
-                flex: 1,
-                paddingTop: theme.spacing.textField.paddingVertical,
-                paddingBottom: theme.spacing.textField.paddingVertical,
-                paddingHorizontal: theme.spacing.textField.paddingHorizontal,
-                color: theme.colors.text.primary,
-                ...theme.typography.basic.input,
-                minHeight: multiline ? 80 : undefined,
-                outline: "none",
-            },
-            placeholder: {
-                color: theme.colors.text.tertiary,
-            },
-        };
-    },
-);

--- a/packages/components/src/components/Input/InputStyle.ts
+++ b/packages/components/src/components/Input/InputStyle.ts
@@ -1,0 +1,62 @@
+import { ViewStyle } from "react-native";
+import { EDSStyleSheet } from "../../styling";
+import { InputProps } from "./Input";
+
+type InputStyleProps = Pick<InputProps, "readOnly" | "variant"> & {
+    isSelected: boolean;
+};
+
+export const themeStyles = EDSStyleSheet.create((theme, props: InputStyleProps) => {
+    const { isSelected, variant, readOnly } = props;
+
+    const backgroundColor = readOnly ? undefined : theme.colors.container.background;
+
+    const variantBorderStyle: ViewStyle = {
+        borderWidth: isSelected
+            ? theme.geometry.border.focusedBorderWidth
+            : theme.geometry.border.borderWidth,
+        borderColor: theme.colors.interactive[variant!],
+    };
+
+    const normalBorderStyle: ViewStyle = {
+        borderColor: isSelected ? theme.colors.interactive.primary : "transparent",
+        borderBottomWidth: theme.geometry.border.focusedBorderWidth,
+        borderBottomColor: isSelected
+            ? theme.colors.interactive.primary
+            : theme.colors.text.tertiary,
+    };
+
+    const readOnlyBorderStyle: ViewStyle = {
+        borderColor: "transparent",
+    };
+
+    let borderStyle: ViewStyle;
+    if (readOnly) {
+        borderStyle = readOnlyBorderStyle;
+    } else if (variant) {
+        borderStyle = variantBorderStyle;
+    } else {
+        borderStyle = normalBorderStyle;
+    }
+
+    return {
+        contentContainer: {
+            backgroundColor,
+            flexDirection: "row",
+            margin: variant && !isSelected ? 1 : 0,
+            borderWidth: theme.geometry.border.focusedBorderWidth,
+            ...borderStyle,
+        },
+        textInput: {
+            flex: 1,
+            paddingTop: theme.spacing.textField.paddingVertical,
+            paddingBottom: theme.spacing.textField.paddingVertical,
+            paddingHorizontal: theme.spacing.textField.paddingHorizontal,
+            color: theme.colors.text.primary,
+            ...theme.typography.basic.input,
+        },
+        placeholder: {
+            color: theme.colors.text.tertiary,
+        },
+    };
+});

--- a/packages/components/src/components/Portal/index.ts
+++ b/packages/components/src/components/Portal/index.ts
@@ -1,4 +1,5 @@
 import { Portal as _Portal, PortalProps } from "./Portal";
+import { PortalProvider } from "./PortalContext";
 import { PortalHost, PortalHostProps } from "./PortalHost";
 
 type PortalFamily = typeof _Portal & {
@@ -8,4 +9,4 @@ type PortalFamily = typeof _Portal & {
 const Portal = _Portal as PortalFamily;
 Portal.Host = PortalHost;
 
-export { Portal, PortalProps, PortalHostProps };
+export { Portal, PortalProvider, PortalProps, PortalHostProps };

--- a/packages/components/src/components/Search/Search.tsx
+++ b/packages/components/src/components/Search/Search.tsx
@@ -1,9 +1,13 @@
 import { MaterialIcons } from "@expo/vector-icons";
 import React, { useEffect, useRef, useState } from "react";
-import { Animated, View } from "react-native";
-import { TextInput } from "react-native-gesture-handler";
-import { Button, InputProps, TextField, useStyles, useToken } from "../..";
-import { EDSStyleSheet } from "../../styling";
+import { Animated, View, TextInput } from "react-native";
+
+import { useToken } from "@/hooks/useToken";
+import { useStyles } from "@/hooks/useStyles";
+import { Button } from "@/components/Button";
+import { TextField } from "@/components/TextField";
+import { InputProps } from "@/components/Input";
+import { EDSStyleSheet } from "@/styling/EDSStyleSheet";
 
 export type SearchProps = Omit<InputProps, "multiline"> & {
     cancellable?: boolean;

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -8,7 +8,13 @@
         "noPropertyAccessFromIndexSignature": true,
         "noImplicitReturns": true,
         "noFallthroughCasesInSwitch": true,
-        "outDir": "./dist"
+        "outDir": "./dist",
+        "paths": {
+            "@/components/*": ["./src/components/*"],
+            "@/hooks/*": ["./src/hooks/*"],
+            "@/styling/*": ["./src/styling/*"],
+            "@/utils/*": ["./src/utils/*"]
+        }
     },
     "include": ["./src"],
     "exclude": ["./src/__tests__", "dist"]

--- a/packages/core/src/components/screens/create-incident/CreateIncidentScreen.tsx
+++ b/packages/core/src/components/screens/create-incident/CreateIncidentScreen.tsx
@@ -104,7 +104,7 @@ export const CreateIncidentScreen = () => {
                         onChange={setTicketTitle}
                         value={ticketTitle}
                         placeholder={"Write a title for the Service Now ticket"}
-                        disabled={isSending}
+                        readOnly={isSending}
                     />
                 </View>
                 <View style={styles.titleField}>
@@ -115,7 +115,7 @@ export const CreateIncidentScreen = () => {
                             "Write a complete description of your issue. You do not need to provide information about your device."
                         }
                         value={ticketDescription}
-                        disabled={isSending}
+                        readOnly={isSending}
                     />
                 </View>
                 <View style={styles.buttonContainer}>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@changesets/cli':
         specifier: ^2.26.0
         version: 2.27.1
-      '@equinor/eslint-config-mad':
-        specifier: workspace:*
-        version: link:packages/eslint-config-mad
       '@types/jest':
         specifier: ^26.0.14
         version: 26.0.24


### PR DESCRIPTION
- add `readOnly` prop to `Input` component
- add example to Chronicles
- refactor `Input` component styling
- add path aliases to mad components
- fix some cyclic deps issues in components