### PR TITLE
fix: rollback tabs render function

### DIFF
--- a/.changeset/calm-bears-look.md
+++ b/.changeset/calm-bears-look.md
@@ -2,4 +2,5 @@
 "@equinor/mad-components": patch
 ---
 
-Rollback changes made in render function in tabs component
+Rollback changes made in render function in tabs component to how it was in 0.9.0 due to an issue
+with the new implementation.

--- a/.changeset/calm-bears-look.md
+++ b/.changeset/calm-bears-look.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-components": patch
+---
+
+Rollback changes made in render function in tabs component

--- a/packages/components/src/components/Tabs/Tabs.tsx
+++ b/packages/components/src/components/Tabs/Tabs.tsx
@@ -31,7 +31,10 @@ export const Tabs = ({ scrollable = false, initialActiveIndex = 0, children }: T
 
     const renderCurrentTabChild = () => {
         const currentChildren = validChildren.at(activeTabIndex);
-        return currentChildren ? currentChildren : null;
+        if (typeof currentChildren === "object") {
+            return currentChildren?.props.children;
+        }
+        return null;
     };
 
     return (


### PR DESCRIPTION
- Rollback `RenderCurrentTabChild` to version prior to release 0.9.0 in mad components