### PR TITLE
fix: add check to `WorkOrderCell` if value is truthy

### DIFF
--- a/.changeset/curly-doors-film.md
+++ b/.changeset/curly-doors-film.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-dfw": patch
+---
+
+Add truhyness check to `PropertyRow` render function to avoid rendering rows with empty values.

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCell.tsx
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCell.tsx
@@ -148,19 +148,22 @@ export const WorkOrderCell = ({
                     ))}
                 <Label label={maintenanceType} style={{ marginBottom: 8 }} />
                 {Object.entries(rest).map(([key, value], index) => {
-                    const label = WorkOrderLabelMap[key as keyof WorkOrder];
-                    let displayValue = value;
-                    if (key === "basicStartDate" || key === "basicEndDate") {
-                        displayValue = value ? new Date(value).toLocaleDateString() : "";
+                    if (value) {
+                        const label = WorkOrderLabelMap[key as keyof WorkOrder];
+                        let displayValue = value;
+                        if (key === "basicStartDate" || key === "basicEndDate") {
+                            displayValue = value ? new Date(value).toLocaleDateString() : "";
+                        }
+                        return (
+                            <PropertyRow
+                                key={index}
+                                label={label}
+                                value={displayValue}
+                                style={{ marginBottom: 8 }}
+                            />
+                        );
                     }
-                    return (
-                        <PropertyRow
-                            key={index}
-                            label={label}
-                            value={displayValue}
-                            style={{ marginBottom: 8 }}
-                        />
-                    );
+                    return null;
                 })}
                 {(!!onStartButtonPress || !!onCompleteButtonPress) && (
                     <View


### PR DESCRIPTION
Add check if `PropertyRow` value is truthy, if it is not, dont render component.