### PR TITLE
fix: menu doesnt rerender when children change

### DIFF
--- a/.changeset/rotten-actors-raise.md
+++ b/.changeset/rotten-actors-raise.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-components": patch
+---
+
+Add update function to menu so that it re-renders when children change

--- a/packages/components/src/components/Menu/Menu.tsx
+++ b/packages/components/src/components/Menu/Menu.tsx
@@ -1,12 +1,13 @@
 import { flip, offset, shift, useFloating } from "@floating-ui/react-native";
 import type { Placement } from "@floating-ui/react-native";
-import React, { createContext } from "react";
+import React, { createContext, useEffect } from "react";
 import { View, ViewProps } from "react-native";
 import { EDSStyleSheet } from "../../styling";
 import { Paper } from "../Paper";
 import { useStyles } from "../../hooks/useStyles";
 import { RootModal } from "../_internal/RootModal";
 import { PopInContainer } from "../_internal/PopInContainer";
+import { useValidChildren } from "../../hooks/useValidChildren";
 
 export type MenuProps = {
     /**
@@ -46,7 +47,7 @@ export const Menu = ({
     children,
     ...rest
 }: React.PropsWithChildren<MenuProps & ViewProps>) => {
-    const { refs, floatingStyles } = useFloating({
+    const { refs, floatingStyles, update } = useFloating({
         sameScrollView: false,
         elements: {
             reference: anchorEl.current,
@@ -54,6 +55,9 @@ export const Menu = ({
         middleware: [offset(8), flip(), shift({ padding: 8 })],
         placement,
     });
+    useEffect(() => {
+        update();
+    }, [children]);
 
     const styles = useStyles(themeStyles);
     return (


### PR DESCRIPTION
Add update function from Floating UI to a useEffect that listens to children of `Menu`.