### PR TITLE
fix(search): adjusted flex and cancel button

### DIFF
--- a/.changeset/happy-rocks-agree.md
+++ b/.changeset/happy-rocks-agree.md
@@ -1,0 +1,7 @@
+---
+"@equinor/mad-components": patch
+---
+
+Fixed flex issue on `Search` that made it hard to have other elements next to it. Prevented that you
+can interact with cancelbutton when it's not showing.  
+

--- a/packages/components/src/components/Search/Search.tsx
+++ b/packages/components/src/components/Search/Search.tsx
@@ -153,11 +153,9 @@ export const Search = ({
             {cancellable && (
                 <Animated.View
                     style={[
-                        {
-                            position: "absolute",
-                            right: 0,
-                        },
                         cancelButtonStyle,
+                        !isInputFocused && { display: "none" },
+                        { position: "absolute", right: 0 },
                     ]}
                     onLayout={event => setCancelButtonWidth(event.nativeEvent.layout.width)}
                 >
@@ -176,6 +174,7 @@ export const Search = ({
 const themedStyles = EDSStyleSheet.create(theme => {
     return {
         container: {
+            flexGrow: 1,
             flexDirection: "row",
             alignItems: "center",
         },


### PR DESCRIPTION
Corrected the flex layout on search.
Made the cancel button hidden / non interactive when the cancel button is not showing.
 