### PR TITLE
fix(search): adjust flex

### DIFF
--- a/.changeset/cuddly-berries-travel.md
+++ b/.changeset/cuddly-berries-travel.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-components": patch
+---
+
+Fix flex issues on `Search` by changing flexGrow to flex

--- a/packages/components/src/components/Search/Search.tsx
+++ b/packages/components/src/components/Search/Search.tsx
@@ -178,7 +178,7 @@ export const Search = ({
 const themedStyles = EDSStyleSheet.create(theme => {
     return {
         container: {
-            flexGrow: 1,
+            flex: 1,
             flexDirection: "row",
             alignItems: "center",
         },


### PR DESCRIPTION
Minor flex adjustments on Search. This prevents adjacent elements to search to go out off the screen.