### PR TITLE
fix(search): prevent search to collapse

### DIFF
--- a/.changeset/nice-bugs-tell.md
+++ b/.changeset/nice-bugs-tell.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-components": patch
+---
+
+Adjusted styling on `Search` to prevent that it collapses in some cases

--- a/packages/components/src/components/Search/Search.tsx
+++ b/packages/components/src/components/Search/Search.tsx
@@ -180,7 +180,6 @@ const themedStyles = EDSStyleSheet.create(theme => {
         container: {
             flex: 1,
             flexDirection: "row",
-            alignItems: "center",
         },
         adornmentIconContainer: {
             position: "absolute",


### PR DESCRIPTION
Adjusted styling on Search to prevent that it collapses in some cases
