### PR TITLE
fix(search): prevent search to collapse

### DIFF
--- a/.changeset/famous-islands-watch.md
+++ b/.changeset/famous-islands-watch.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-components": patch
+---
+
+Adjusted styling on Search to prevent that it collapses in some cases

--- a/packages/components/src/components/Search/Search.tsx
+++ b/packages/components/src/components/Search/Search.tsx
@@ -110,7 +110,7 @@ export const Search = ({
 
     return (
         <View style={styles.container}>
-            <Animated.View style={[{ flex: 1 }, inputStyle]}>
+            <Animated.View style={inputStyle}>
                 <TextField
                     {...restProps}
                     readOnly={disabled}
@@ -178,8 +178,7 @@ export const Search = ({
 const themedStyles = EDSStyleSheet.create(theme => {
     return {
         container: {
-            flex: 1,
-            flexDirection: "row",
+            flexGrow: 1,
         },
         adornmentIconContainer: {
             position: "absolute",


### PR DESCRIPTION
Adjusted styling on Search to prevent that it collapses in some cases