### PR TITLE
fix: remove unnecessary flex in `PropertyRow` value

### DIFF
--- a/.changeset/afraid-bikes-enjoy.md
+++ b/.changeset/afraid-bikes-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-dfw": patch
+---
+
+`PropertyRow` now correctly displays value when not in a `ScrollView` and on mobile

--- a/packages/dfw/src/dfwcomponents/PropertyRow/PropertyRow.tsx
+++ b/packages/dfw/src/dfwcomponents/PropertyRow/PropertyRow.tsx
@@ -42,7 +42,6 @@ export const PropertyRow = ({ label, value, iconName, ...rest }: PropertyRowProp
                     group="paragraph"
                     variant="body_short"
                     color="textTertiary"
-                    style={{ flex: 1 }}
                     numberOfLines={1}
                 >
                     {value}


### PR DESCRIPTION
Removed unnecessary flex style that made the Value of the `PropertyRow` collapse when not in a `ScrollView` on mobile.

Key changes:
- Value now shows when using the `PropertyRow` in a normal `View` on mobile. 