### PR TITLE
build(docs): create `docs-deploy` workflow for deploying docs page

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
     "access": "public",
     "baseBranch": "main",
     "updateInternalDependencies": "patch",
-    "ignore": ["@equinor/mad-chronicles", "tsconfig", "@equinor/mad-platform-docs"]
+    "ignore": ["@equinor/mad-chronicles", "tsconfig"]
 }

--- a/.changeset/two-owls-pull.md
+++ b/.changeset/two-owls-pull.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-platform-docs": patch
+---
+
+Initial release

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,35 @@
+name: Deploy to GitHub Pages
+
+on:
+    workflow_call:
+
+permissions:
+    contents: write
+
+jobs:
+    deploy:
+        name: Deploy to GitHub Pages
+        runs-on: ubuntu-latest
+        steps:
+            - name: 👀 Checkout Repo
+              uses: actions/checkout@v4
+
+            - name: 🌈 Setup Node.js 18
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 18
+                  cache: pnpm
+
+            - name: 📦 Install Dependencies
+              run: pnpm install
+
+            - name: 👩‍🏭 Build website
+              run: pnpm build:docs
+
+            # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
+            - name: ⬆️ Deploy to GitHub Pages
+              uses: peaceiris/actions-gh-pages@v3
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  # Build output to publish to the `gh-pages` branch:
+                  publish_dir: ./apps/docs/build

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,5 +1,4 @@
 name: Deploy to GitHub Pages
-
 on:
     workflow_call:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,9 @@ jobs:
                   commit: "📝 chore: Bump package versions and write changelog"
                   createGithubReleases: true
                   publish: pnpm publish:all
-
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+            - name: 📗 Trigger Docs Deploy Workflow
+              uses: equinor/mad/.github/workflows/deploy-docs.yml@main
+              if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
- De-ignore docs package from changesets (it is still ignored for npmjs publishing)
- Create docs deploy workflow
- Create initial changeset