### PR TITLE
fix(core): package mismatch between docusaurus and react native render html

### DIFF
--- a/.changeset/hungry-points-train.md
+++ b/.changeset/hungry-points-train.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-core": minor
+---
+
+use react-native-markdown-display for release notes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,8 @@
         "@equinor/mad-insights": "workspace:*",
         "@equinor/mad-navigation": "workspace:*",
         "@react-navigation/elements": "1.3.21",
-        "showdown": "2.1.0",
+        "markdown-it": "^14.0.0",
+        "react-native-markdown-display": "^7.0.2",
         "zustand": "^4.4.1"
     },
     "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,6 @@
         "@equinor/mad-insights": "workspace:*",
         "@equinor/mad-navigation": "workspace:*",
         "@react-navigation/elements": "1.3.21",
-        "react-native-render-html": "6.3.4",
         "showdown": "2.1.0",
         "zustand": "^4.4.1"
     },

--- a/packages/core/src/components/screens/release-notes/ChangeLog.tsx
+++ b/packages/core/src/components/screens/release-notes/ChangeLog.tsx
@@ -1,9 +1,8 @@
-import React, { useMemo, useState } from "react";
+import React from "react";
 import { View } from "react-native";
-import * as showdown from "showdown";
-import { EDSStyleSheet, useStyles, Typography } from "@equinor/mad-components";
+import { EDSStyleSheet, useStyles } from "@equinor/mad-components";
+import Markdown from "react-native-markdown-display";
 
-const converter = new showdown.Converter();
 
 export type Release = {
     app: string;
@@ -19,35 +18,29 @@ type ChangeLogProps = {
 
 export const ChangeLog = ({ release }: ChangeLogProps) => {
     const styles = useStyles(changeLogStyles);
-    const [width, setWidth] = useState(0);
-    const html = useMemo(() => ({ html: converter.makeHtml(release.releaseNote) }), [release]);
-
     return (
-        <>
-            <View
-                onLayout={event => {
-                    const { width } = event.nativeEvent.layout;
-                    setWidth(width);
-                }}
-            >
-                <Typography> Release notes unavailable. Check back soon!</Typography>
-            </View>
-        </>
+        <View>
+            <Markdown style={styles}>{release.releaseNote}</Markdown>
+        </View>
     );
 };
 
 const changeLogStyles = EDSStyleSheet.create(theme => ({
-    list: {
-        display: "flex",
-        listStyleType: "square",
-        alignItems: "flex-start",
-        paddingLeft: theme.spacing.container.paddingHorizontal,
-        marginVertical: theme.spacing.textField.paddingVertical,
+    text: {
+        ...theme.typography.paragraph.body_short,
         color: theme.colors.text.primary,
     },
-    listItems: {
-        ...theme.typography.paragraph.body_short,
+    bullet_list: {
+        display: "flex",
+        alignItems: "flex-start",
+        marginVertical: theme.spacing.textField.paddingVertical,
+    },
+    list_item: {
         marginHorizontal: theme.spacing.textField.paddingHorizontal,
         paddingBottom: theme.spacing.textField.paddingVertical,
     },
+    bullet_list_icon: {
+        fontSize: 32,
+        lineHeight: 28
+    }
 }));

--- a/packages/core/src/components/screens/release-notes/ChangeLog.tsx
+++ b/packages/core/src/components/screens/release-notes/ChangeLog.tsx
@@ -1,11 +1,9 @@
 import React, { useMemo, useState } from "react";
 import { View } from "react-native";
-import RenderHtml, { defaultSystemFonts } from "react-native-render-html";
 import * as showdown from "showdown";
-import { EDSStyleSheet, useStyles } from "@equinor/mad-components";
+import { EDSStyleSheet, useStyles, Typography } from "@equinor/mad-components";
 
 const converter = new showdown.Converter();
-const systemFonts = [...defaultSystemFonts, "Equinor-Regular"];
 
 export type Release = {
     app: string;
@@ -32,16 +30,7 @@ export const ChangeLog = ({ release }: ChangeLogProps) => {
                     setWidth(width);
                 }}
             >
-                <RenderHtml
-                    contentWidth={width}
-                    source={html}
-                    systemFonts={systemFonts}
-                    tagsStyles={{
-                        ul: styles.list,
-                        // @ts-expect-error Type Mismatch between react-native TextStyle and react-native-render-html
-                        li: styles.listItems,
-                    }}
-                />
+                <Typography> Release notes unavailable. Check back soon!</Typography>
             </View>
         </>
     );

--- a/packages/core/src/components/screens/release-notes/ChangeLog.tsx
+++ b/packages/core/src/components/screens/release-notes/ChangeLog.tsx
@@ -3,7 +3,6 @@ import { View } from "react-native";
 import { EDSStyleSheet, useStyles } from "@equinor/mad-components";
 import Markdown from "react-native-markdown-display";
 
-
 export type Release = {
     app: string;
     version: string;
@@ -27,20 +26,23 @@ export const ChangeLog = ({ release }: ChangeLogProps) => {
 
 const changeLogStyles = EDSStyleSheet.create(theme => ({
     text: {
-        ...theme.typography.paragraph.body_short,
+        ...theme.typography.basic.p,
         color: theme.colors.text.primary,
     },
     bullet_list: {
         display: "flex",
         alignItems: "flex-start",
         marginVertical: theme.spacing.textField.paddingVertical,
+        listStyleType: "square",
     },
     list_item: {
         marginHorizontal: theme.spacing.textField.paddingHorizontal,
         paddingBottom: theme.spacing.textField.paddingVertical,
     },
     bullet_list_icon: {
-        fontSize: 32,
-        lineHeight: 28
-    }
+        ...theme.typography.basic.p,
+        fontSize: 48,
+        lineHeight: 40,
+        color: theme.colors.text.primary,
+    },
 }));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,6 +328,9 @@ importers:
       expo-localization:
         specifier: '>=14.3.0'
         version: 14.3.0(expo@49.0.21)
+      markdown-it:
+        specifier: ^14.0.0
+        version: 14.0.0
       react:
         specifier: '>=18.0'
         version: 18.2.0
@@ -340,12 +343,12 @@ importers:
       react-native-gesture-handler:
         specifier: ^2.14.0
         version: 2.14.0(react-native@0.72.6)(react@18.2.0)
+      react-native-markdown-display:
+        specifier: ^7.0.2
+        version: 7.0.2(react-native@0.72.6)(react@18.2.0)
       react-native-msal:
         specifier: '*'
         version: 4.0.4(react-native@0.72.6)(react@18.2.0)
-      showdown:
-        specifier: 2.1.0
-        version: 2.1.0
       zustand:
         specifier: ^4.4.1
         version: 4.4.7(react@18.2.0)
@@ -6861,6 +6864,10 @@ packages:
     engines: {node: '>=14.16'}
     dev: false
 
+  /camelize@1.0.1:
+    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
+    dev: false
+
   /caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
     dependencies:
@@ -7488,6 +7495,11 @@ packages:
       type-fest: 1.4.0
     dev: false
 
+  /css-color-keywords@1.0.0:
+    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
+    engines: {node: '>=4'}
+    dev: false
+
   /css-declaration-sorter@6.4.1(postcss@8.4.32):
     resolution: {integrity: sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==}
     engines: {node: ^10 || ^12 || >=14}
@@ -7603,6 +7615,14 @@ packages:
       domhandler: 5.0.3
       domutils: 3.1.0
       nth-check: 2.1.1
+    dev: false
+
+  /css-to-react-native@3.2.0:
+    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
+    dependencies:
+      camelize: 1.0.1
+      css-color-keywords: 1.0.0
+      postcss-value-parser: 4.2.0
     dev: false
 
   /css-tree@1.1.3:
@@ -8200,6 +8220,10 @@ packages:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
     dev: true
+
+  /entities@2.0.3:
+    resolution: {integrity: sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==}
+    dev: false
 
   /entities@2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
@@ -11536,6 +11560,18 @@ packages:
   /lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  /linkify-it@2.2.0:
+    resolution: {integrity: sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==}
+    dependencies:
+      uc.micro: 1.0.6
+    dev: false
+
+  /linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+    dependencies:
+      uc.micro: 2.1.0
+    dev: false
+
   /load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -11729,6 +11765,29 @@ packages:
   /markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
     engines: {node: '>=16'}
+
+  /markdown-it@10.0.0:
+    resolution: {integrity: sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==}
+    hasBin: true
+    dependencies:
+      argparse: 1.0.10
+      entities: 2.0.3
+      linkify-it: 2.2.0
+      mdurl: 1.0.1
+      uc.micro: 1.0.6
+    dev: false
+
+  /markdown-it@14.0.0:
+    resolution: {integrity: sha512-seFjF0FIcPt4P9U39Bq1JYblX0KZCjDLFFQPHpL5AzHpqPEKtosxmdq/LTVZnjfH7tjt9BxStm+wXcDBNuYmzw==}
+    hasBin: true
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+    dev: false
 
   /markdown-table@3.0.3:
     resolution: {integrity: sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==}
@@ -11978,6 +12037,14 @@ packages:
 
   /mdn-data@2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
+    dev: false
+
+  /mdurl@1.0.1:
+    resolution: {integrity: sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==}
+    dev: false
+
+  /mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
     dev: false
 
   /media-typer@0.3.0:
@@ -14145,6 +14212,11 @@ packages:
       once: 1.4.0
     dev: false
 
+  /punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+    dev: false
+
   /punycode@1.4.1:
     resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
     dev: false
@@ -14425,6 +14497,12 @@ packages:
       react-native: 0.72.6(@babel/core@7.23.6)(@babel/preset-env@7.23.6)(react@18.2.0)
     dev: false
 
+  /react-native-fit-image@1.5.5:
+    resolution: {integrity: sha512-Wl3Vq2DQzxgsWKuW4USfck9zS7YzhvLNPpkwUUCF90bL32e1a0zOVQ3WsJILJOwzmPdHfzZmWasiiAUNBkhNkg==}
+    dependencies:
+      prop-types: 15.8.1
+    dev: false
+
   /react-native-gesture-handler@2.12.1(react-native@0.72.6)(react@18.2.0):
     resolution: {integrity: sha512-deqh36bw82CFUV9EC4tTo2PP1i9HfCOORGS3Zmv71UYhEZEHkzZv18IZNPB+2Awzj45vLIidZxGYGFxHlDSQ5A==}
     peerDependencies:
@@ -14453,6 +14531,20 @@ packages:
       prop-types: 15.8.1
       react: 18.2.0
       react-native: 0.72.6(@babel/core@7.23.6)(@babel/preset-env@7.23.6)(react@18.2.0)
+    dev: false
+
+  /react-native-markdown-display@7.0.2(react-native@0.72.6)(react@18.2.0):
+    resolution: {integrity: sha512-Mn4wotMvMfLAwbX/huMLt202W5DsdpMO/kblk+6eUs55S57VVNni1gzZCh5qpznYLjIQELNh50VIozEfY6fvaQ==}
+    peerDependencies:
+      react: '>=16.2.0'
+      react-native: '>=0.50.4'
+    dependencies:
+      css-to-react-native: 3.2.0
+      markdown-it: 10.0.0
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-native: 0.72.6(@babel/core@7.23.6)(@babel/preset-env@7.23.6)(react@18.2.0)
+      react-native-fit-image: 1.5.5
     dev: false
 
   /react-native-msal@4.0.4(react-native@0.72.6)(react@18.2.0):
@@ -15494,13 +15586,6 @@ packages:
       glob: 7.2.3
       interpret: 1.4.0
       rechoir: 0.6.2
-    dev: false
-
-  /showdown@2.1.0:
-    resolution: {integrity: sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==}
-    hasBin: true
-    dependencies:
-      commander: 9.5.0
     dev: false
 
   /side-channel@1.0.4:
@@ -16612,6 +16697,14 @@ packages:
 
   /ua-parser-js@1.0.37:
     resolution: {integrity: sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ==}
+    dev: false
+
+  /uc.micro@1.0.6:
+    resolution: {integrity: sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==}
+    dev: false
+
+  /uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
     dev: false
 
   /uglify-es@3.3.9:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,15 +343,12 @@ importers:
       react-native-msal:
         specifier: '*'
         version: 4.0.4(react-native@0.72.6)(react@18.2.0)
-      react-native-render-html:
-        specifier: 6.3.4
-        version: 6.3.4(@types/react-native@0.72.8)(@types/react@18.2.45)(react-native@0.72.6)(react@18.2.0)
       showdown:
         specifier: 2.1.0
         version: 2.1.0
       zustand:
         specifier: ^4.4.1
-        version: 4.4.7(@types/react@18.2.45)(react@18.2.0)
+        version: 4.4.7(react@18.2.0)
     devDependencies:
       '@babel/core':
         specifier: ^7.21.4
@@ -4105,22 +4102,6 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
-  /@jsamr/counter-style@2.0.2:
-    resolution: {integrity: sha512-2mXudGVtSzVxWEA7B9jZLKjoXUeUFYDDtFrQoC0IFX9/Dszz4t1vZOmafi3JSw/FxD+udMQ+4TAFR8Qs0J3URQ==}
-    dev: false
-
-  /@jsamr/react-native-li@2.3.1(@jsamr/counter-style@2.0.2)(react-native@0.72.6)(react@18.2.0):
-    resolution: {integrity: sha512-Qbo4NEj48SQ4k8FZJHFE2fgZDKTWaUGmVxcIQh3msg5JezLdTMMHuRRDYctfdHI6L0FZGObmEv3haWbIvmol8w==}
-    peerDependencies:
-      '@jsamr/counter-style': ^1.0.0 || ^2.0.0
-      react: '*'
-      react-native: '*'
-    dependencies:
-      '@jsamr/counter-style': 2.0.2
-      react: 18.2.0
-      react-native: 0.72.6(@babel/core@7.23.6)(@babel/preset-env@7.23.6)(react@18.2.0)
-    dev: false
-
   /@jsdevtools/ono@7.1.3:
     resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
     dev: true
@@ -4347,38 +4328,6 @@ packages:
     resolution: {integrity: sha512-MB8trWaFREpmb037k/d0bB7T2BP7Ai24w1e1tbz3ASLB0/lwphsq3Nq8S9I5AsI5vs4zAQT+SB5nC5/dLYTiOg==}
     dependencies:
       '@nevware21/ts-utils': 0.10.1
-    dev: false
-
-  /@native-html/css-processor@1.11.0(@types/react-native@0.72.8)(@types/react@18.2.45):
-    resolution: {integrity: sha512-NnhBEbJX5M2gBGltPKOetiLlKhNf3OHdRafc8//e2ZQxXN8JaSW/Hy8cm94pnIckQxwaMKxrtaNT3x4ZcffoNQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-native': '*'
-    dependencies:
-      '@types/react': 18.2.45
-      '@types/react-native': 0.72.8(react-native@0.72.6)
-      css-to-react-native: 3.2.0
-      csstype: 3.1.3
-    dev: false
-
-  /@native-html/transient-render-engine@11.2.3(@types/react-native@0.72.8)(@types/react@18.2.45)(react-native@0.72.6):
-    resolution: {integrity: sha512-zXwgA3gPUEmFs3I3syfnvDvS6WiUHXEE6jY09OBzK+trq7wkweOSFWIoyXiGkbXrozGYG0KY90YgPyr8Tg8Uyg==}
-    peerDependencies:
-      '@types/react-native': '*'
-      react-native: ^*
-    dependencies:
-      '@native-html/css-processor': 1.11.0(@types/react-native@0.72.8)(@types/react@18.2.45)
-      '@types/ramda': 0.27.66
-      '@types/react-native': 0.72.8(react-native@0.72.6)
-      csstype: 3.1.3
-      domelementtype: 2.3.0
-      domhandler: 4.3.1
-      domutils: 2.8.0
-      htmlparser2: 7.2.0
-      ramda: 0.27.2
-      react-native: 0.72.6(@babel/core@7.23.6)(@babel/preset-env@7.23.6)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
     dev: false
 
   /@nevware21/ts-async@0.3.0:
@@ -5435,12 +5384,6 @@ packages:
     resolution: {integrity: sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw==}
     dev: false
 
-  /@types/ramda@0.27.66:
-    resolution: {integrity: sha512-i2YW+E2U6NfMt3dp0RxNcejox+bxJUNDjB7BpYuRuoHIzv5juPHkJkNgcUOu+YSQEmaWu8cnAo/8r63C0NnuVA==}
-    dependencies:
-      ts-toolbelt: 6.15.5
-    dev: false
-
   /@types/range-parser@1.2.7:
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
     dev: false
@@ -5450,15 +5393,6 @@ packages:
     dependencies:
       '@types/react': 18.2.45
     dev: true
-
-  /@types/react-native@0.72.8(react-native@0.72.6):
-    resolution: {integrity: sha512-St6xA7+EoHN5mEYfdWnfYt0e8u6k2FR0P9s2arYgakQGFgU1f9FlPrIEcj0X24pLCF5c5i3WVuLCUdiCYHmOoA==}
-    dependencies:
-      '@react-native/virtualized-lists': 0.72.8(react-native@0.72.6)
-      '@types/react': 18.2.45
-    transitivePeerDependencies:
-      - react-native
-    dev: false
 
   /@types/react-router-config@5.0.11:
     resolution: {integrity: sha512-WmSAg7WgqW7m4x8Mt4N6ZyKz0BubSj/2tVUMsAHp+Yd2AMwcSbeFq9WympT19p5heCFmF97R9eD5uUR/t4HEqw==}
@@ -5542,10 +5476,6 @@ packages:
 
   /@types/unist@3.0.2:
     resolution: {integrity: sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==}
-
-  /@types/urijs@1.19.25:
-    resolution: {integrity: sha512-XOfUup9r3Y06nFAZh3WvO0rBU4OtlfPB/vgxpjg+NRdGU6CN6djdc6OEiH+PcqHCY6eFLo9Ista73uarf4gnBg==}
-    dev: false
 
   /@types/ws@8.5.10:
     resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
@@ -6931,10 +6861,6 @@ packages:
     engines: {node: '>=14.16'}
     dev: false
 
-  /camelize@1.0.1:
-    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
-    dev: false
-
   /caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
     dependencies:
@@ -6984,16 +6910,8 @@ packages:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
 
-  /character-entities-html4@1.1.4:
-    resolution: {integrity: sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g==}
-    dev: false
-
   /character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
-
-  /character-entities-legacy@1.1.4:
-    resolution: {integrity: sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==}
-    dev: false
 
   /character-entities-legacy@3.0.0:
     resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
@@ -7570,11 +7488,6 @@ packages:
       type-fest: 1.4.0
     dev: false
 
-  /css-color-keywords@1.0.0:
-    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
-    engines: {node: '>=4'}
-    dev: false
-
   /css-declaration-sorter@6.4.1(postcss@8.4.32):
     resolution: {integrity: sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==}
     engines: {node: ^10 || ^12 || >=14}
@@ -7690,14 +7603,6 @@ packages:
       domhandler: 5.0.3
       domutils: 3.1.0
       nth-check: 2.1.1
-    dev: false
-
-  /css-to-react-native@3.2.0:
-    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
-    dependencies:
-      camelize: 1.0.1
-      css-color-keywords: 1.0.0
-      postcss-value-parser: 4.2.0
     dev: false
 
   /css-tree@1.1.3:
@@ -8298,11 +8203,6 @@ packages:
 
   /entities@2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
-    dev: false
-
-  /entities@3.0.1:
-    resolution: {integrity: sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==}
-    engines: {node: '>=0.12'}
     dev: false
 
   /entities@4.5.0:
@@ -10167,15 +10067,6 @@ packages:
       domhandler: 4.3.1
       domutils: 2.8.0
       entities: 2.2.0
-    dev: false
-
-  /htmlparser2@7.2.0:
-    resolution: {integrity: sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==}
-    dependencies:
-      domelementtype: 2.3.0
-      domhandler: 4.3.1
-      domutils: 2.8.0
-      entities: 3.0.1
     dev: false
 
   /htmlparser2@8.0.2:
@@ -14333,10 +14224,6 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /ramda@0.27.2:
-    resolution: {integrity: sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==}
-    dev: false
-
   /randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
     dependencies:
@@ -14632,28 +14519,6 @@ packages:
       invariant: 2.2.4
       react: 18.2.0
       react-native: 0.72.6(@babel/core@7.23.6)(@babel/preset-env@7.23.6)(react@18.2.0)
-    dev: false
-
-  /react-native-render-html@6.3.4(@types/react-native@0.72.8)(@types/react@18.2.45)(react-native@0.72.6)(react@18.2.0):
-    resolution: {integrity: sha512-H2jSMzZjidE+Wo3qCWPUMU1nm98Vs2SGCvQCz/i6xf0P3Y9uVtG/b0sDbG/cYFir2mSYBYCIlS1Dv0WC1LjYig==}
-    peerDependencies:
-      react: '*'
-      react-native: '*'
-    dependencies:
-      '@jsamr/counter-style': 2.0.2
-      '@jsamr/react-native-li': 2.3.1(@jsamr/counter-style@2.0.2)(react-native@0.72.6)(react@18.2.0)
-      '@native-html/transient-render-engine': 11.2.3(@types/react-native@0.72.8)(@types/react@18.2.45)(react-native@0.72.6)
-      '@types/ramda': 0.27.66
-      '@types/urijs': 1.19.25
-      prop-types: 15.8.1
-      ramda: 0.27.2
-      react: 18.2.0
-      react-native: 0.72.6(@babel/core@7.23.6)(@babel/preset-env@7.23.6)(react@18.2.0)
-      stringify-entities: 3.1.0
-      urijs: 1.19.11
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-native'
     dev: false
 
   /react-native-safe-area-context@4.6.3(react-native@0.72.6)(react@18.2.0):
@@ -16015,14 +15880,6 @@ packages:
     dependencies:
       safe-buffer: 5.2.1
 
-  /stringify-entities@3.1.0:
-    resolution: {integrity: sha512-3FP+jGMmMV/ffZs86MoghGqAoqXAdxLrJP4GUdrDN1aIScYih5tuIO3eF4To5AJZ79KDZ8Fpdy7QJnK8SsL1Vg==}
-    dependencies:
-      character-entities-html4: 1.1.4
-      character-entities-legacy: 1.1.4
-      xtend: 4.0.2
-    dev: false
-
   /stringify-entities@4.0.3:
     resolution: {integrity: sha512-BP9nNHMhhfcMbiuQKCqMjhDP5yBCAxsPu4pHFFzJ6Alo9dZgY4VLDPutXqIjpRiMoKdp7Av85Gr73Q5uH9k7+g==}
     dependencies:
@@ -16505,10 +16362,6 @@ packages:
       yn: 3.1.1
     dev: true
 
-  /ts-toolbelt@6.15.5:
-    resolution: {integrity: sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==}
-    dev: false
-
   /tsconfig-paths@3.14.2:
     resolution: {integrity: sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==}
     dependencies:
@@ -16954,10 +16807,6 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.3.1
-
-  /urijs@1.19.11:
-    resolution: {integrity: sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==}
-    dev: false
 
   /url-join@4.0.0:
     resolution: {integrity: sha512-EGXjXJZhIHiQMK2pQukuFcL303nskqIRzWvPvV5O8miOfwoUb9G+a/Cld60kUyeaybEI94wvVClT10DtfeAExA==}
@@ -17652,7 +17501,7 @@ packages:
     engines: {node: '>=12.20'}
     dev: false
 
-  /zustand@4.4.7(@types/react@18.2.45)(react@18.2.0):
+  /zustand@4.4.7(react@18.2.0):
     resolution: {integrity: sha512-QFJWJMdlETcI69paJwhSMJz7PPWjVP8Sjhclxmxmxv/RYI7ZOvR5BHX+ktH0we9gTWQMxcne8q1OY8xxz604gw==}
     engines: {node: '>=12.7.0'}
     peerDependencies:
@@ -17667,7 +17516,6 @@ packages:
       react:
         optional: true
     dependencies:
-      '@types/react': 18.2.45
       react: 18.2.0
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false


### PR DESCRIPTION
Fix issue related to docusaurus and react-native-render-html requiring different versions of "entities" by migrating to react-native-markdown-display package. also eliminates the need for "showdown"