### PR TITLE
fix: correct color in dark mode for chip and menu

### DIFF
--- a/.changeset/tasty-planets-dance.md
+++ b/.changeset/tasty-planets-dance.md
@@ -1,0 +1,7 @@
+---
+"@equinor/mad-components": patch
+---
+
+Added new color variable and adjusted the selectedHighlight and menu active color for dark mode in
+order to prevent that text and background had the same color.  
+

--- a/packages/components/src/styling/colors.ts
+++ b/packages/components/src/styling/colors.ts
@@ -8,6 +8,7 @@ export const colors = {
     interactive_primary_dark_resting: "#97CACE",
     interactive_primary_dark_hover: "#ADE2E6",
     interactive_primary_dark_hover_alt: "#ADE2E619",
+    interactive_primary_dark_selected_highlight: "#17485D",
     interactive_secondary_light_resting: "#243746",
     interactive_secondary_light_link_hover: "#18252F",
     interactive_secondary_light_highlight: "#D5EAF4",

--- a/packages/components/src/styling/masterToken.ts
+++ b/packages/components/src/styling/masterToken.ts
@@ -94,7 +94,7 @@ export const masterToken: MasterToken = {
             },
             selectedHighlight: {
                 light: colors.interactive_primary_light_selected_highlight,
-                dark: colors.interactive_primary_dark_resting,
+                dark: colors.interactive_primary_dark_selected_highlight,
             },
         },
         feedback: {
@@ -153,7 +153,7 @@ export const masterToken: MasterToken = {
                 },
                 active: {
                     light: colors.interactive_primary_light_resting,
-                    dark: colors.text_and_static_icons_dark_primary_black,
+                    dark: colors.interactive_primary_dark_resting,
                 },
             },
             danger: {


### PR DESCRIPTION
Active chip had a issue where the background color and text color was the same.
Correct the text and background color in dark mode for chip and menu. 

**Key changes:**
- Added new color, `interactive_primary_dark_selected_highlight`
- Updated the color for text - menu - active - dark. 

It now looks like this:
![image](https://github.com/equinor/mad/assets/83707387/a8301d2c-b0f5-4c19-98a4-d2c4307fee0c)

Fixes: #343 