### PR TITLE
fix(actions): Update lint-pr.yml

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -33,7 +33,7 @@ jobs:
                   cache-dependency-path: yarn.lock
 
             - name: 📦 Install Dependencies
-              run: yarn install --frozen-lockfile
+              run: yarn install --frozen-lockfile --network-concurrency 1
 
             - name: 🏭 Build packages
               run: yarn build:all


### PR DESCRIPTION
Adds temporary workaround to the concurrency issue plagueing the Code Validator github action.

Longterm fix is probably to migrate to Yarn Modern
ref: https://github.com/yarnpkg/yarn/issues/7212