### PR TITLE
feat: add text color support for `PropertyRow` and `WorkOrderCell`

### DIFF
--- a/.changeset/few-needles-tell.md
+++ b/.changeset/few-needles-tell.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-dfw": minor
+---
+
+Add textcolor support for propertyrow and workordercell and add requiredEnd prop to workordercell

--- a/apps/chronicles/screens/dfw/dfwcomponents/PropertyRowScreen.tsx
+++ b/apps/chronicles/screens/dfw/dfwcomponents/PropertyRowScreen.tsx
@@ -19,7 +19,7 @@ export const PropertyRowScreen = () => {
             </View>
             <Spacer />
             <View style={styles.propertyRowContainer}>
-                <PropertyRow label="Label" value="Value" textColor="danger" />
+                <PropertyRow label="Label" value="Value" />
             </View>
             <Spacer />
             <View style={styles.readableContent}>
@@ -38,6 +38,20 @@ export const PropertyRowScreen = () => {
                     value="LOC-10234 - Zone 3 - Central Facility"
                     iconName="barrel"
                 />
+            </View>
+            <Spacer />
+            <View style={styles.readableContent}>
+                <Typography>
+                    You can also change the text color of the value by passing a color prop to the
+                    PropertyRow component. The default color is textTertiary.
+                </Typography>
+            </View>
+            <Spacer />
+            <View style={styles.propertyRowContainer}>
+                <PropertyRow label="Label" value="Default" />
+                <PropertyRow label="Label" value="Success" textColor="success" />
+                <PropertyRow label="Label" value="Warning" textColor="warning" />
+                <PropertyRow label="Label" value="Danger" textColor="danger" />
             </View>
         </ScrollView>
     );

--- a/apps/chronicles/screens/dfw/dfwcomponents/PropertyRowScreen.tsx
+++ b/apps/chronicles/screens/dfw/dfwcomponents/PropertyRowScreen.tsx
@@ -19,7 +19,7 @@ export const PropertyRowScreen = () => {
             </View>
             <Spacer />
             <View style={styles.propertyRowContainer}>
-                <PropertyRow label="Label" value="Value" />
+                <PropertyRow label="Label" value="Value" textColor="danger" />
             </View>
             <Spacer />
             <View style={styles.readableContent}>

--- a/apps/chronicles/screens/dfw/dfwcomponents/WorkOrderCellScreen.tsx
+++ b/apps/chronicles/screens/dfw/dfwcomponents/WorkOrderCellScreen.tsx
@@ -28,6 +28,7 @@ export const WorkOrderCellScreen = () => {
                 activeStatusIds="STRT"
                 basicStartDate="2023-04-07"
                 basicEndDate="2023-09-12"
+                requiredEnd="2024-04-23"
                 workCenterId="POMISP"
                 onCompleteButtonPress={() => console.log("Complete")}
                 onStartButtonPress={() => console.log("Start")}
@@ -63,6 +64,7 @@ export const WorkOrderCellScreen = () => {
                 workOrderId="25282760"
                 maintenanceType="Surface monitoring"
                 tagId="TAG-123456"
+                valueColor={"danger"}
             />
         </ScrollView>
     );

--- a/packages/dfw/src/dfwcomponents/PropertyRow/PropertyRow.tsx
+++ b/packages/dfw/src/dfwcomponents/PropertyRow/PropertyRow.tsx
@@ -7,6 +7,7 @@ import {
     IconName,
     Icon,
     Typography,
+    Color,
 } from "@equinor/mad-components";
 import { View, ViewProps } from "react-native";
 type PropertyRowStyleProps = {
@@ -16,8 +17,15 @@ export type PropertyRowProps = {
     label: string;
     value: string;
     iconName?: IconName;
+    textColor?: Color;
 } & ViewProps;
-export const PropertyRow = ({ label, value, iconName, ...rest }: PropertyRowProps) => {
+export const PropertyRow = ({
+    label,
+    value,
+    iconName,
+    textColor = "textTertiary",
+    ...rest
+}: PropertyRowProps) => {
     const breakpoint = useBreakpoint();
     const styles = useStyles(themeStyles, { breakpoint });
     const renderIcon = () =>
@@ -41,7 +49,7 @@ export const PropertyRow = ({ label, value, iconName, ...rest }: PropertyRowProp
                 <Typography
                     group="paragraph"
                     variant="body_short"
-                    color="textTertiary"
+                    color={textColor}
                     numberOfLines={1}
                 >
                     {value}

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCell.tsx
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCell.tsx
@@ -160,6 +160,7 @@ export const WorkOrderCell = ({
                                 label={label}
                                 value={displayValue}
                                 style={{ marginBottom: 8 }}
+                                textColor={"textTertiary"}
                             />
                         );
                     }

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCell.tsx
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCell.tsx
@@ -22,6 +22,7 @@ const WorkOrderLabelMap: Record<keyof WorkOrder, string> = {
     activeStatusIds: "Active Status IDs",
     basicStartDate: "Basic Start Date",
     basicEndDate: "Basic End Date",
+    requiredEnd: "Required End",
     workCenterId: "Work Center ID",
 } as const;
 
@@ -34,6 +35,7 @@ export type WorkOrder = {
     activeStatusIds?: string;
     basicStartDate?: string;
     basicEndDate?: string;
+    requiredEnd?: string;
     workCenterId?: string;
 };
 
@@ -42,6 +44,7 @@ export type WorkOrderCellProps = {
     onCompleteButtonPress?: () => void;
     onPress?: () => void;
     showSymbols?: boolean;
+    valueColor?: Color;
 } & WorkOrder;
 
 type StatusConfig = {
@@ -85,17 +88,19 @@ export const WorkOrderCell = ({
     onCompleteButtonPress,
     onPress,
     showSymbols,
+    valueColor = "textTertiary",
     ...rest
 }: WorkOrderCellProps) => {
     const styles = useStyles(themeStyles);
     const activeStatuses = rest.activeStatusIds?.split(" ");
 
+    const currentDate = new Date();
+    const requiredEnd = rest.requiredEnd ? new Date(rest.requiredEnd) : null;
+
     const iconsAndLabels = useMemo(() => {
-        const currentDate = new Date();
-        const endDate = rest.basicEndDate ? new Date(rest.basicEndDate) : null;
         const result: StatusConfig[] = [];
 
-        if (endDate && currentDate > endDate) {
+        if (requiredEnd && currentDate > requiredEnd) {
             result.push({
                 icon: "alarm",
                 label: "Required end overdue",
@@ -111,7 +116,7 @@ export const WorkOrderCell = ({
             }
         });
         return result;
-    }, [activeStatuses, rest.basicEndDate]);
+    }, [activeStatuses, rest.requiredEnd]);
 
     const isStartDisabled =
         !!activeStatuses?.includes("STRT") || !!activeStatuses?.includes("RDOP");
@@ -151,8 +156,17 @@ export const WorkOrderCell = ({
                     if (value) {
                         const label = WorkOrderLabelMap[key as keyof WorkOrder];
                         let displayValue = value;
-                        if (key === "basicStartDate" || key === "basicEndDate") {
+                        let requiredEndColor = valueColor;
+
+                        if (
+                            key === "basicStartDate" ||
+                            key === "basicEndDate" ||
+                            key === "requiredEnd"
+                        ) {
                             displayValue = value ? new Date(value).toLocaleDateString() : "";
+                        }
+                        if (key === "requiredEnd" && requiredEnd && currentDate > requiredEnd) {
+                            requiredEndColor = "danger";
                         }
                         return (
                             <PropertyRow
@@ -160,7 +174,7 @@ export const WorkOrderCell = ({
                                 label={label}
                                 value={displayValue}
                                 style={{ marginBottom: 8 }}
-                                textColor={"textTertiary"}
+                                textColor={requiredEndColor}
                             />
                         );
                     }


### PR DESCRIPTION
Add TextColor prop to propertyrow
Add requiredEnd prop to workordercell
Add logic for conditionally rendering text color based on required end date

Breaking change:
Required end icon display now listens to RequiredEnd prop and not start & end date