### PR TITLE
fix(select): make select and multiselect responsive

### DIFF
--- a/.changeset/happy-starfishes-greet.md
+++ b/.changeset/happy-starfishes-greet.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-components": patch
+---
+
+Added flex to the `Select` and `Select.Multi` components

--- a/packages/components/src/components/Select/Multiselect.tsx
+++ b/packages/components/src/components/Select/Multiselect.tsx
@@ -57,7 +57,7 @@ export const Multiselect = <T,>({
     };
 
     return (
-        <View>
+        <View style={{ flexGrow: 1 }}>
             <Pressable
                 style={inputStyles.contentContainer}
                 ref={triggerRef}

--- a/packages/components/src/components/Select/Select.tsx
+++ b/packages/components/src/components/Select/Select.tsx
@@ -57,7 +57,7 @@ export const Select = <T,>({
     };
 
     return (
-        <View>
+        <View style={{ flexGrow: 1 }}>
             <Pressable
                 style={inputStyles.contentContainer}
                 ref={triggerRef}


### PR DESCRIPTION
Prevent Select and MultiSelect to from "collapsing" when using flex direction row.

Fixes: #506 