### PR TITLE
fix(input): add color to input

### DIFF
--- a/.changeset/poor-penguins-applaud.md
+++ b/.changeset/poor-penguins-applaud.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-components": patch
+---
+
+Added text color in the `Input` component in order to prevent dark text color in dark mode

--- a/packages/components/src/components/Input/inputStyle.ts
+++ b/packages/components/src/components/Input/inputStyle.ts
@@ -52,6 +52,7 @@ export const inputTokenStyles = EDSStyleSheet.create((token, props: InputStylePr
             paddingTop: token.spacing.textField.paddingVertical,
             paddingBottom: token.spacing.textField.paddingVertical,
             paddingHorizontal: token.spacing.textField.paddingHorizontal,
+            color: token.colors.text.primary,
             ...token.typography.basic.input,
         },
         placeholder: {


### PR DESCRIPTION
Corrected the text color in the`Input` component, which is being used in both `TextField` and `Search`. This should now work fine in both light and dark mode.

Fixes: #517 