### PR TITLE
feat(Progress): Touch up `Progress` component

### DIFF
--- a/.changeset/little-kids-tan.md
+++ b/.changeset/little-kids-tan.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-components": patch
+---
+
+`Progress.Item` tasks are now allowed to use more screen estate

--- a/.changeset/tame-owls-sniff.md
+++ b/.changeset/tame-owls-sniff.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-components": patch
+---
+
+"Copy to clipboard" button for task errors now render under the respective error

--- a/.changeset/young-beds-own.md
+++ b/.changeset/young-beds-own.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-components": patch
+---
+
+`Progress.Item` task lines now visually indicate the current progress better

--- a/apps/chronicles/hooks/useProgressUpload.ts
+++ b/apps/chronicles/hooks/useProgressUpload.ts
@@ -16,14 +16,15 @@ const simulateTask = (duration: number, shouldFail = false) => {
     });
 };
 
-export const useProgressUpload = () => {
+export const useProgressUpload = (animal: "dog" | "cat") => {
+    const animalRhyme = animal === "dog" ? "DogThrowingVeryLongLog" : "CatWithHat";
     const [tasks, setTasks] = useState<ProgressTask[]>([
-        { title: "CatWithHat1.jpg", status: "notStarted" },
-        { title: "CatWithHat2.jpg", status: "notStarted" },
-        { title: "CatWithHat3.jpg", status: "notStarted" },
-        { title: "CatWithHat4.jpg", status: "notStarted" },
-        { title: "CatWithHat5.jpg", status: "notStarted" },
-        { title: "CatWithHat6.jpg", status: "notStarted" },
+        { title: `${animalRhyme}1.jpg`, status: "notStarted" },
+        { title: `${animalRhyme}2.jpg`, status: "notStarted" },
+        { title: `${animalRhyme}3.jpg`, status: "notStarted" },
+        { title: `${animalRhyme}4.jpg`, status: "notStarted" },
+        { title: `${animalRhyme}5.jpg`, status: "notStarted" },
+        { title: `${animalRhyme}6.jpg`, status: "notStarted" },
     ]);
 
     const [isSimulating, setIsSimulating] = useState(false);
@@ -47,7 +48,7 @@ export const useProgressUpload = () => {
         setTasks(
             tasks.map((task, index) => ({
                 ...task,
-                title: `CatWithHat${index + 1}.jpg`,
+                title: `${animalRhyme}${index + 1}.jpg`,
                 status: "notStarted",
                 error: undefined,
             })),
@@ -61,20 +62,19 @@ export const useProgressUpload = () => {
         for (let i = 0; i < tasks.length; i++) {
             if (scenario === "success" || (scenario === "fail" && i !== 3)) {
                 updateTaskStatus(i, "inProgress");
-                await simulateTask(1000);
+                await simulateTask(Math.random() * 2500);
                 updateTaskStatus(i, "success");
             } else if (scenario === "fail" && i === 3) {
                 updateTaskStatus(
                     i,
                     "error",
                     {
-                        message:
-                            "Critical error: Expected CatWithHat4.jpg, but detected DogThrowingLog4.jpg",
+                        message: `Critical error: Expected ${animalRhyme}4.jpg, but detected MouseInDaHouse4.jpg`,
                         code: "Error code: 403",
                         suggestion:
                             "Immediate action required. Ensure system security protocols are enforced and consult security logs for potential intrusions.",
                     },
-                    "DogThrowingLog4.jpg",
+                    `${animalRhyme}4.jpg`,
                 );
                 break;
             }

--- a/apps/chronicles/navigation/index.tsx
+++ b/apps/chronicles/navigation/index.tsx
@@ -96,7 +96,7 @@ function DiscoverNavigator() {
                 },
                 headerBackTitleStyle: { fontFamily: "Equinor-Regular" },
                 customSubHeaderShown: false,
-                headerRight: () => <GoToSettingsButton marginRight={-12} />,
+                headerRight: () => <GoToSettingsButton />,
             }}
         >
             <ComponentsStack.Screen name="Discover" component={DiscoverScreen} />

--- a/apps/chronicles/screens/components/components/ProgressScreen.tsx
+++ b/apps/chronicles/screens/components/components/ProgressScreen.tsx
@@ -11,6 +11,11 @@ import {
 import { ScrollView, View } from "react-native";
 import { useProgressUpload } from "../../../hooks/useProgressUpload";
 
+type UploadSimulatorProps = {
+    onUploadSuccess: () => void;
+    onUploadFailed: () => void;
+};
+
 const UploadSimulator = ({ onUploadSuccess, onUploadFailed }: UploadSimulatorProps) => {
     const styles = useStyles(themeStyles);
 
@@ -21,34 +26,38 @@ const UploadSimulator = ({ onUploadSuccess, onUploadFailed }: UploadSimulatorPro
             </Typography>
             <Typography>Press the buttons below to simulate the progress component</Typography>
             <View style={styles.simulateButtonContainer}>
-                <Button
-                    title="Run successfull progress"
-                    onPress={() => {
-                        onUploadSuccess();
-                    }}
-                />
+                <Button title="Run successfull progress" onPress={onUploadSuccess} />
                 <Button title="Run failed progress" onPress={onUploadFailed} />
             </View>
         </View>
     );
 };
 
-type UploadSimulatorProps = {
-    onUploadSuccess: () => void;
-    onUploadFailed: () => void;
-};
-
 export const ProgressScreen = () => {
-    const { tasks, startUploadSimulation, handleCopyErrorMessage, handleRetry } =
-        useProgressUpload();
+    const {
+        tasks: catTasks,
+        startUploadSimulation: startCatUpload,
+        handleCopyErrorMessage: handleCopyCatErrorMessage,
+        handleRetry: handleRetryCatUpload,
+    } = useProgressUpload("cat");
+
+    const {
+        tasks: dogTasks,
+        startUploadSimulation: startDogUpload,
+        handleCopyErrorMessage: handleCopyDogErrorMessage,
+        handleRetry: handleRetryDogUpload,
+    } = useProgressUpload("dog");
+
     const styles = useStyles(themeStyles);
 
-    const handleUploadSuccess = async () => {
-        await startUploadSimulation("success");
+    const handleUploadSuccess = () => {
+        void startCatUpload("success");
+        void startDogUpload("success");
     };
 
-    const handleUploadFailed = async () => {
-        await startUploadSimulation("fail");
+    const handleUploadFailed = () => {
+        void startCatUpload("fail");
+        void startDogUpload("fail");
     };
 
     return (
@@ -56,41 +65,52 @@ export const ProgressScreen = () => {
             contentInsetAdjustmentBehavior="automatic"
             contentContainerStyle={styles.contentContainer}
         >
-            <Typography group="basic" variant="h2">
-                Progress
-            </Typography>
+            <View style={styles.textContainer}>
+                <Typography group="basic" variant="h2">
+                    Progress
+                </Typography>
 
-            <Typography>
-                The Progress component can be used for tracking and displaying the progress of tasks
-                or processes, such as «create folder» or «upload images».
-            </Typography>
-            <Typography>
-                Progress can be used with one or multiple Progress Items, and one Progress Item can
-                contain one single task or multiple tasks.
-            </Typography>
-
-            <Spacer amount="small" />
-            <Typography>
-                Tasks have different statuses that is based on the overall progress.
-            </Typography>
-            <Typography> Status can either be:</Typography>
-            <View style={{ flexDirection: "row", gap: 8, alignItems: "center" }}>
-                <Typography color="primary">inProgress</Typography>
-                <CircularProgress size={18} value={0.7} />
-                <Typography color="textTertiary">, notStarted, </Typography>
-                <Typography color="success">sucess</Typography>
-                <Typography>or</Typography>
-                <Typography color="danger">error</Typography>
+                <Typography>
+                    The Progress component can be used for tracking and displaying the progress of
+                    tasks or processes, such as «create folder» or «upload images».
+                </Typography>
+                <Typography>
+                    Progress can be used with one or multiple Progress Items, and one Progress Item
+                    can contain one single task or multiple tasks.
+                </Typography>
             </View>
+
             <Spacer amount="small" />
-            <UploadSimulator
-                onUploadSuccess={() => void handleUploadSuccess()}
-                onUploadFailed={() => void handleUploadFailed()}
-            />
+
+            <View style={styles.textContainer}>
+                <Typography>
+                    Tasks have different statuses that is based on the overall progress.
+                </Typography>
+                <Typography> Status can either be:</Typography>
+                <View style={{ flexDirection: "row", gap: 8, alignItems: "center" }}>
+                    <Typography color="primary">inProgress</Typography>
+                    <CircularProgress size={18} value={0.7} />
+                    <Typography color="textTertiary">, notStarted, </Typography>
+                    <Typography color="success">sucess</Typography>
+                    <Typography>or</Typography>
+                    <Typography color="danger">error</Typography>
+                </View>
+            </View>
+
+            <Spacer amount="small" />
+
+            <View style={styles.textContainer}>
+                <UploadSimulator
+                    onUploadSuccess={() => void handleUploadSuccess()}
+                    onUploadFailed={() => void handleUploadFailed()}
+                />
+            </View>
 
             <Spacer />
 
-            <Typography>Progress with one single task: </Typography>
+            <View style={styles.textContainer}>
+                <Typography>Progress with one single task: </Typography>
+            </View>
 
             <Spacer amount="small" />
             <Progress title="Create folder">
@@ -103,22 +123,37 @@ export const ProgressScreen = () => {
 
             <Spacer />
 
-            <Typography>Progress with multiple tasks: </Typography>
+            <View style={styles.textContainer}>
+                <Typography>Progress with multiple tasks: </Typography>
+            </View>
+
             <Spacer amount="small" />
-            <Progress title="Upload cat images">
+
+            <Progress title="Upload animal images">
                 <Progress.Item
-                    title="Upload images of cats with hats"
+                    title="Upload images of cats"
                     description="uploading cats with hats"
-                    tasks={tasks}
-                    onCopyTextButtonPress={handleCopyErrorMessage}
-                    onRetryButtonPress={() => void handleRetry()}
+                    tasks={catTasks}
+                    onCopyTextButtonPress={handleCopyCatErrorMessage}
+                    onRetryButtonPress={() => void handleRetryCatUpload()}
+                />
+                <Progress.Item
+                    title="Upload images of dogs throwing logs"
+                    description="uploading dogs throwing logs"
+                    tasks={dogTasks}
+                    onCopyTextButtonPress={handleCopyDogErrorMessage}
+                    onRetryButtonPress={() => void handleRetryDogUpload()}
                 />
             </Progress>
 
             <Spacer />
 
-            <Typography>Progress with multiple progress items:</Typography>
+            <View style={styles.textContainer}>
+                <Typography>Progress with multiple progress items:</Typography>
+            </View>
+
             <Spacer amount="small" />
+
             <Progress title="Multiple progress items">
                 <Progress.Item title="Preparing cat hats" status="success" />
                 <Progress.Item title="Training cats to wear hats" status="inProgress" />
@@ -136,10 +171,11 @@ export const ProgressScreen = () => {
 
 const themeStyles = EDSStyleSheet.create(theme => ({
     contentContainer: {
-        paddingHorizontal: theme.spacing.container.paddingHorizontal,
         paddingVertical: theme.spacing.container.paddingVertical,
     },
-
+    textContainer: {
+        paddingHorizontal: theme.spacing.container.paddingHorizontal,
+    },
     uploadSimulatorContainer: {
         paddingVertical: theme.spacing.container.paddingVertical,
         gap: theme.spacing.cell.content.titleDescriptionGap,

--- a/packages/components/src/components/Progress/ProgressExpandButton.tsx
+++ b/packages/components/src/components/Progress/ProgressExpandButton.tsx
@@ -18,23 +18,23 @@ export const ProgressExpandButton = ({
 }: ProgressExpandButtonProps) => {
     const breakpoint = useBreakpoint();
 
-    let title;
-    if (breakpoint === "xs") {
-        title = isExpanded ? "Hide" : "Show";
-    } else {
-        title = isExpanded ? "Show less" : "Show more";
-    }
-
     return (
         taskStatus !== "notStarted" &&
-        taskCounter > 0 && (
+        taskCounter > 0 &&
+        (breakpoint === "xs" ? (
+            <Button.Icon
+                name={isExpanded ? "chevron-up" : "chevron-down"}
+                variant="ghost"
+                onPress={toggleExpand}
+            />
+        ) : (
             <Button
                 iconName={isExpanded ? "chevron-up" : "chevron-down"}
-                title={title}
+                title={isExpanded ? "Show less" : "Show more"}
                 iconPosition="trailing"
                 onPress={toggleExpand}
                 variant="ghost"
-            ></Button>
-        )
+            />
+        ))
     );
 };

--- a/packages/components/src/components/Progress/ProgressItem.tsx
+++ b/packages/components/src/components/Progress/ProgressItem.tsx
@@ -3,7 +3,6 @@ import { View } from "react-native";
 import { useStyles } from "../../hooks/useStyles";
 import { EDSStyleSheet } from "../../styling";
 import { Button } from "../Button";
-import { Spacer } from "../Spacer";
 import { Typography } from "../Typography";
 import { ProgressExpandButton } from "./ProgressExpandButton";
 import { ProgressExpandableSection } from "./ProgressExpandableSection";
@@ -103,18 +102,19 @@ export const ProgressItem = ({
     }, [taskHasError, failedTask]);
 
     const renderItemText = () => (
-        <View>
+        <View style={styles.descriptionTextContainer}>
             <Typography
+                numberOfLines={1}
                 bold={taskStatus !== "success"}
                 color={taskStatus === "notStarted" ? "textDisabled" : "textPrimary"}
-                variant="body_short"
-                group="paragraph"
+                group="cell"
+                variant="title"
             >
                 {title}
             </Typography>
 
-            {description ? (
-                <View style={styles.descriptionContainer}>
+            {description && (
+                <>
                     {taskStatus !== "notStarted" && taskCounter > 0 ? (
                         <Typography variant="description" group="cell">
                             {completedTaskCounter} / {taskCounter} {description}
@@ -128,57 +128,61 @@ export const ProgressItem = ({
                             {description}
                         </Typography>
                     )}
-                </View>
-            ) : null}
+                </>
+            )}
         </View>
     );
 
     return (
-        <View style={styles.progressContainer}>
-            <View style={styles.mainContentContainer}>
-                <View style={styles.statusAndTextContainer}>
-                    <ProgressItemStatus
-                        style={styles.status}
-                        taskCounter={taskCounter}
-                        status={taskStatus}
-                    />
-                    <View style={styles.textContainer}>
+        <View style={styles.container}>
+            <View style={styles.topRowContainer}>
+                <ProgressItemStatus
+                    style={styles.status}
+                    taskCounter={taskCounter}
+                    status={taskStatus}
+                />
+                <View style={{ flex: 1 }}>
+                    <View
+                        style={{
+                            flexDirection: "row",
+                            justifyContent: "space-between",
+                        }}
+                    >
                         {renderItemText()}
-                        <ProgressExpandableSection expanded={isExpanded}>
-                            <Spacer amount="small" />
-                            <View style={styles.progressTaskItemContainer}>
-                                {tasks.map((task, index) => (
+                        <ProgressExpandButton
+                            taskStatus={taskStatus}
+                            taskCounter={taskCounter}
+                            isExpanded={isExpanded}
+                            toggleExpand={toggleExpand}
+                        />
+                    </View>
+
+                    <ProgressExpandableSection expanded={isExpanded}>
+                        <View style={styles.progressTaskItemContainer}>
+                            {tasks.map((task, index) => (
+                                <>
                                     <ProgressTaskItem
                                         key={index}
                                         task={task}
                                         status={task.status}
                                     />
-                                ))}
-                            </View>
-                        </ProgressExpandableSection>
-                    </View>
+                                    {onCopyTextButtonPress && isExpanded && task?.error && (
+                                        <Button
+                                            title="Copy to clipboard"
+                                            iconName="clipboard-outline"
+                                            variant="outlined"
+                                            onPress={handleCopyTextButtonPress}
+                                        />
+                                    )}
+                                </>
+                            ))}
+                        </View>
+                    </ProgressExpandableSection>
                 </View>
-                <ProgressExpandButton
-                    taskStatus={taskStatus}
-                    taskCounter={taskCounter}
-                    isExpanded={isExpanded}
-                    toggleExpand={toggleExpand}
-                />
             </View>
 
-            {taskHasError && (onCopyTextButtonPress ?? onRetryButtonPress) ? (
-                <View style={[styles.actionContainer, !failedTask?.error && { marginTop: 0 }]}>
-                    {onCopyTextButtonPress && isExpanded && failedTask?.error && (
-                        <Button
-                            title="Copy to clipboard"
-                            variant="outlined"
-                            onPress={handleCopyTextButtonPress}
-                        />
-                    )}
-                    {onRetryButtonPress && (
-                        <Button title="Retry" onPress={handleRetryButtonPress} />
-                    )}
-                </View>
+            {taskHasError && onRetryButtonPress ? (
+                <Button iconName="restart" title="Retry" onPress={handleRetryButtonPress} />
             ) : null}
         </View>
     );
@@ -187,39 +191,24 @@ export const ProgressItem = ({
 ProgressItem.displayName = "Progress.Item";
 
 const themeStyles = EDSStyleSheet.create(theme => ({
-    progressContainer: {
+    container: {
         backgroundColor: theme.colors.container.default,
         paddingHorizontal: theme.spacing.menu.item.paddingHorizontal,
         borderRadius: theme.geometry.border.elementBorderRadius,
         justifyContent: "space-between",
         flexDirection: "column",
     },
-    mainContentContainer: {
-        flex: 1,
+    topRowContainer: {
         flexDirection: "row",
-        justifyContent: "space-between",
+        alignItems: "center",
         paddingVertical: theme.spacing.container.paddingVertical,
     },
-    statusAndTextContainer: {
+    descriptionTextContainer: {
         flex: 1,
-        flexDirection: "row",
-        alignItems: "center",
-    },
-    descriptionContainer: {
-        flexDirection: "row",
-        alignItems: "center",
-        gap: theme.spacing.button.iconGap,
-    },
-    textContainer: {
-        flex: 1,
-        flexDirection: "column",
-    },
-    actionContainer: {
-        marginTop: theme.spacing.container.paddingVertical,
-        marginBottom: theme.spacing.container.paddingVertical,
-        gap: theme.spacing.spacer.small,
+        gap: theme.spacing.cell.content.titleDescriptionGap,
     },
     progressTaskItemContainer: {
+        paddingVertical: theme.spacing.element.paddingVertical,
         gap: theme.spacing.cell.gapHorizontal,
     },
     status: {

--- a/packages/components/src/components/Progress/ProgressItemStatus.tsx
+++ b/packages/components/src/components/Progress/ProgressItemStatus.tsx
@@ -17,7 +17,7 @@ export const ProgressItemStatus = ({ taskCounter, status, style }: ProgressItemS
     const token = useToken();
 
     return (
-        <View style={[{ flexDirection: "column", gap: 8, height: "100%" }, style]}>
+        <View style={[{ gap: 8, height: "100%" }, style]}>
             {status === "inProgress" ? (
                 <CircularProgress size={26} />
             ) : (

--- a/packages/components/src/components/Progress/ProgressTaskItem.tsx
+++ b/packages/components/src/components/Progress/ProgressTaskItem.tsx
@@ -55,7 +55,14 @@ export const ProgressTaskItem = ({ task, status }: ProgressTaskProps) => {
         <View style={styles.taskContainer}>
             <View style={styles.taskTitleContainer}>
                 {taskStatusIndicator}
-                <Typography>{task.title}</Typography>
+                <Typography
+                    group="paragraph"
+                    variant="body_short"
+                    bold={task.status === "error" || task.status === "inProgress"}
+                    color={status === "notStarted" ? "textTertiary" : "textPrimary"}
+                >
+                    {task.title}
+                </Typography>
             </View>
             {showErrorDetails && renderError()}
         </View>
@@ -64,7 +71,7 @@ export const ProgressTaskItem = ({ task, status }: ProgressTaskProps) => {
 
 const themeStyles = EDSStyleSheet.create(theme => ({
     taskContainer: {
-        gap: theme.spacing.cell.content.titleDescriptionGap,
+        gap: theme.spacing.element.paddingVertical,
     },
     taskTitleContainer: {
         flexDirection: "row",


### PR DESCRIPTION
### Key changes
- Change Typography and spacing for progress items
- Dynamically style progress item task lines based on task status
- Switch expand `Button` for `Button.Icon` on smaller screens to give more room for progress item title
- Restructure `ProgressItem` component layout to accomodate for more space available in task container
- Add dog example progress to `ProgressScreen` in Chronicles

### Other changes
- Remove margin in settings button in Chronicles

closes #543 