### PR TITLE
feat(progress): add icon to progress tasks

### DIFF
--- a/.changeset/metal-parents-live.md
+++ b/.changeset/metal-parents-live.md
@@ -1,0 +1,6 @@
+---
+"@equinor/mad-components": patch
+---
+
+Fixed issue where tasks with removed status was not included in the task counter in the `Progress`
+component

--- a/.changeset/rich-countries-drop.md
+++ b/.changeset/rich-countries-drop.md
@@ -1,0 +1,6 @@
+---
+"@equinor/mad-components": patch
+---
+
+Added new `icon` and `iconColor` props, allowing users to display an icon on the right side of the
+progress task title in the `Progress` component.

--- a/apps/chronicles/hooks/useProgressUpload.ts
+++ b/apps/chronicles/hooks/useProgressUpload.ts
@@ -32,18 +32,21 @@ export const useProgressUpload = (animal: "dog" | "cat") => {
         {
             title: `${animalRhyme}1.jpg`,
             status: "notStarted",
+            icon: animal,
             onCopyTextButtonPress: handleCopyErrorMessage,
             onRetryButtonPress: () => void handleRetry(),
         },
         {
             title: `${animalRhyme}2.jpg`,
             status: "notStarted",
+            icon: animal,
             onCopyTextButtonPress: handleCopyErrorMessage,
             onRetryButtonPress: () => void handleRetry(),
         },
         {
             title: `${animalRhyme}3.jpg`,
             status: "notStarted",
+            icon: animal,
             onCopyTextButtonPress: handleCopyErrorMessage,
             onRetryButtonPress: () => void handleRetry(),
         },

--- a/packages/components/src/components/Progress/ProgressExpandableSection.tsx
+++ b/packages/components/src/components/Progress/ProgressExpandableSection.tsx
@@ -54,7 +54,7 @@ export const ProgressExpandableSection = ({
 
     return (
         <Animated.View style={[animatedStyle, { overflow: "hidden" }]}>
-            <View style={{ position: "absolute" }} onLayout={onLayout}>
+            <View style={{ position: "absolute", width: "100%" }} onLayout={onLayout}>
                 {children}
             </View>
         </Animated.View>

--- a/packages/components/src/components/Progress/ProgressItem.tsx
+++ b/packages/components/src/components/Progress/ProgressItem.tsx
@@ -62,8 +62,10 @@ export const ProgressItem = ({
 
     const styles = useStyles(themeStyles);
 
-    const taskCounter = tasks?.filter(task => task.status !== "removed").length;
-    const completedTaskCounter = tasks?.filter(task => task.status === "success").length;
+    const taskCounter = tasks?.length;
+    const completedTaskCounter = tasks?.filter(
+        task => task.status === "success" || task.status === "removed",
+    ).length;
 
     const taskStatus = computeTaskStatus(tasks, status);
     const taskHasError = taskStatus === "error";

--- a/packages/components/src/components/Progress/ProgressTaskItem.tsx
+++ b/packages/components/src/components/Progress/ProgressTaskItem.tsx
@@ -132,7 +132,6 @@ const themeStyles = EDSStyleSheet.create(theme => ({
         gap: theme.spacing.button.iconGap,
     },
     icon: {
-        justifyContent: "flex-end",
         paddingHorizontal: theme.spacing.button.paddingHorizontal,
     },
     errorContainer: {

--- a/packages/components/src/components/Progress/ProgressTaskItem.tsx
+++ b/packages/components/src/components/Progress/ProgressTaskItem.tsx
@@ -129,6 +129,7 @@ const themeStyles = EDSStyleSheet.create(theme => ({
     },
     taskStatusAndTitle: {
         flexDirection: "row",
+        alignItems: "center",
         gap: theme.spacing.button.iconGap,
     },
     icon: {

--- a/packages/components/src/components/Progress/ProgressTaskItem.tsx
+++ b/packages/components/src/components/Progress/ProgressTaskItem.tsx
@@ -74,22 +74,32 @@ export const ProgressTaskItem = ({
     );
 
     return (
-        <View style={styles.taskContainer}>
-            <View style={styles.taskTitleContainer}>
-                {taskStatusIndicator}
-                <Typography
-                    group="paragraph"
-                    variant="body_short"
-                    bold={task.status === "error" || task.status === "inProgress"}
-                    color={
-                        status === "notStarted" || status === "removed"
-                            ? "textTertiary"
-                            : "textPrimary"
-                    }
-                >
-                    {task.title}
-                </Typography>
+        <View style={styles.container}>
+            <View style={styles.taskContainer}>
+                <View style={styles.taskStatusAndTitle}>
+                    {taskStatusIndicator}
+                    <Typography
+                        group="paragraph"
+                        variant="body_short"
+                        bold={task.status === "error" || task.status === "inProgress"}
+                        color={
+                            status === "notStarted" || status === "removed"
+                                ? "textTertiary"
+                                : "textPrimary"
+                        }
+                    >
+                        {task.title}
+                    </Typography>
+                </View>
+                {task.icon && (
+                    <Icon
+                        color={task.iconColor ?? "secondary"}
+                        style={styles.icon}
+                        name={task.icon}
+                    />
+                )}
             </View>
+
             {showErrorDetails && renderError()}
             <View style={styles.actionContainer}>
                 {onCopyTextButtonPress && task?.status === "error" && (
@@ -109,12 +119,21 @@ export const ProgressTaskItem = ({
 };
 
 const themeStyles = EDSStyleSheet.create(theme => ({
-    taskContainer: {
+    container: {
         gap: theme.spacing.element.paddingVertical,
     },
-    taskTitleContainer: {
+    taskContainer: {
+        flexDirection: "row",
+        justifyContent: "space-between",
+        alignItems: "center",
+    },
+    taskStatusAndTitle: {
         flexDirection: "row",
         gap: theme.spacing.button.iconGap,
+    },
+    icon: {
+        justifyContent: "flex-end",
+        paddingHorizontal: theme.spacing.button.paddingHorizontal,
     },
     errorContainer: {
         flexDirection: "column",

--- a/packages/components/src/components/Progress/types.ts
+++ b/packages/components/src/components/Progress/types.ts
@@ -1,4 +1,3 @@
-import { Color } from "../../styling";
 import { IconName } from "../Icon";
 
 export type ProgressStatus = "success" | "error" | "notStarted" | "inProgress" | "removed";

--- a/packages/components/src/components/Progress/types.ts
+++ b/packages/components/src/components/Progress/types.ts
@@ -1,3 +1,6 @@
+import { Color } from "../../styling";
+import { IconName } from "../Icon";
+
 export type ProgressStatus = "success" | "error" | "notStarted" | "inProgress" | "removed";
 
 export type ProgressTaskError = {
@@ -20,6 +23,14 @@ export type ProgressTask = {
      * The title of the task. This should be a concise but descriptive string that identifies the task being performed to the user.
      */
     title: string;
+    /**
+     * This is an optional icon that can be displayed next to the task title on the right side to provide visual context for the task being performed.
+     */
+    icon?: IconName;
+    /**
+     * The color of the icon.
+     */
+    iconColor?: "primary" | "secondary" | "danger";
     /**
      * The current status of the task. This status should reflect where in the execution process the task currently is, such as 'notStarted', 'inProgress', 'success', or 'error'.
      */


### PR DESCRIPTION
***Key changes:***
- Fixed issue where tasks with removed status was not included in the task counter in the `Progress`
component
- Added new `icon` and `iconColor` props, allowing users to display an icon on the right side of the