### PR TITLE
fix: Add selectable prop to PropertyRow

### DIFF
--- a/.changeset/thirty-papayas-cry.md
+++ b/.changeset/thirty-papayas-cry.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-dfw": patch
+---
+
+Added a selectable prop to the PropertyRow component

--- a/packages/dfw/src/dfwcomponents/PropertyRow/PropertyRow.tsx
+++ b/packages/dfw/src/dfwcomponents/PropertyRow/PropertyRow.tsx
@@ -18,12 +18,14 @@ export type PropertyRowProps = {
     value: string;
     iconName?: IconName;
     textColor?: Color;
+    selectable?: boolean;
 } & ViewProps;
 export const PropertyRow = ({
     label,
     value,
     iconName,
     textColor = "textTertiary",
+    selectable,
     ...rest
 }: PropertyRowProps) => {
     const breakpoint = useBreakpoint();
@@ -51,6 +53,7 @@ export const PropertyRow = ({
                     variant="body_short"
                     color={textColor}
                     numberOfLines={1}
+                    selectable={selectable}
                 >
                     {value}
                 </Typography>


### PR DESCRIPTION
Adds a selectable prop to the PropertyRow component. This makes the value property selectable on iOS.