### PR TITLE
feat(skia): add image encoding options to makeImageSnapshot

### DIFF
--- a/.changeset/cool-pans-remain.md
+++ b/.changeset/cool-pans-remain.md
@@ -1,6 +1,8 @@
 ---
-"@equinor/react-native-skia-draw": patch
+"@equinor/react-native-skia-draw": minor
 ---
 
-Add support for setting encoding options on the `makeImageSnapshot` method and expose raw base64
-image data.
+-   **BREAKING:** Change method signature of `makeImageSnapshot` to only accept the
+    `ImageSnapshotConfig` object (was previously `SKRect`).
+-   Add support for setting encoding options on the `makeImageSnapshot` method.
+-   Expose raw base64 data through the `makeImageSnapshot` method.

--- a/.changeset/cool-pans-remain.md
+++ b/.changeset/cool-pans-remain.md
@@ -1,0 +1,6 @@
+---
+"@equinor/react-native-skia-draw": patch
+---
+
+Add support for setting encoding options on the `makeImageSnapshot` method and expose raw base64
+image data.

--- a/apps/chronicles/screens/DrawScreen.tsx
+++ b/apps/chronicles/screens/DrawScreen.tsx
@@ -1,8 +1,8 @@
+import React, { useRef, useState } from "react";
 import { View, StyleSheet, Image } from "react-native";
 import { CanvasImageControls, ImageMarkup } from "@equinor/react-native-skia-draw";
 import { Button, Typography } from "@equinor/mad-components";
 import * as ImagePicker from "expo-image-picker";
-import React, { useRef, useState } from "react";
 
 export const DrawScreen = () => {
     const canvasHandle = useRef<CanvasImageControls>(null);

--- a/packages/skia-draw/src/CanvasControlProvider/types.ts
+++ b/packages/skia-draw/src/CanvasControlProvider/types.ts
@@ -1,6 +1,6 @@
 import type { Color, SkRect } from "@shopify/react-native-skia";
 import type { CanvasTool } from "../Canvas/types";
-import { SkiaDrawSnapshot } from "../types";
+import { ImageSnapshotEncodingOptions, SkiaDrawSnapshot } from "../types";
 
 export type CanvasControlProviderProps = {
     /**
@@ -63,7 +63,10 @@ export type CanvasControlContextValues = {
 export type CanvasControls = {
     undo: () => void;
     clear: () => void;
-    makeImageSnapshot: (rect?: SkRect) => SkiaDrawSnapshot | undefined;
+    makeImageSnapshot: (
+        rect?: SkRect,
+        encodingOptions?: ImageSnapshotEncodingOptions,
+    ) => SkiaDrawSnapshot | undefined;
 };
 
 export type CanvasImageControls = Pick<Partial<CanvasControls>, "makeImageSnapshot">;

--- a/packages/skia-draw/src/CanvasControlProvider/types.ts
+++ b/packages/skia-draw/src/CanvasControlProvider/types.ts
@@ -1,4 +1,4 @@
-import type { Color, SkRect } from "@shopify/react-native-skia";
+import type { Color } from "@shopify/react-native-skia";
 import type { CanvasTool } from "../Canvas/types";
 import { ImageSnapshotConfig, SkiaDrawSnapshot } from "../types";
 

--- a/packages/skia-draw/src/CanvasControlProvider/types.ts
+++ b/packages/skia-draw/src/CanvasControlProvider/types.ts
@@ -1,6 +1,6 @@
 import type { Color, SkRect } from "@shopify/react-native-skia";
 import type { CanvasTool } from "../Canvas/types";
-import { ImageSnapshotEncodingOptions, SkiaDrawSnapshot } from "../types";
+import { ImageSnapshotConfig, SkiaDrawSnapshot } from "../types";
 
 export type CanvasControlProviderProps = {
     /**
@@ -63,10 +63,7 @@ export type CanvasControlContextValues = {
 export type CanvasControls = {
     undo: () => void;
     clear: () => void;
-    makeImageSnapshot: (
-        rect?: SkRect,
-        encodingOptions?: ImageSnapshotEncodingOptions,
-    ) => SkiaDrawSnapshot | undefined;
+    makeImageSnapshot: (config?: ImageSnapshotConfig) => SkiaDrawSnapshot | undefined;
 };
 
 export type CanvasImageControls = Pick<Partial<CanvasControls>, "makeImageSnapshot">;

--- a/packages/skia-draw/src/hooks/useDrawHandle.ts
+++ b/packages/skia-draw/src/hooks/useDrawHandle.ts
@@ -1,8 +1,15 @@
 import { ForwardedRef, MutableRefObject, RefObject, useImperativeHandle } from "react";
-import { SkiaDomView, SkRect } from "@shopify/react-native-skia";
+import { ImageFormat, SkiaDomView, SkRect } from "@shopify/react-native-skia";
 import { useRerender } from "./useRerender";
 import { CanvasData } from "../Canvas/types";
 import { CanvasControls } from "../CanvasControlProvider";
+import { ImageSnapshotEncodingOptions, SkiaDrawSnapshot } from "../types";
+
+const ImageFormatMimeTypeMap: Record<ImageFormat, string> = {
+    [ImageFormat.JPEG]: "image/jpeg",
+    [ImageFormat.PNG]: "image/png",
+    [ImageFormat.WEBP]: "image/webp",
+};
 
 /**
  * responsible for providing the methods available in the ref object like undo, clear, etc.
@@ -30,14 +37,20 @@ export const useCanvasControlHandle = (
         rerender();
     };
 
-    const makeImageSnapshot = (rect?: SkRect) => {
+    const makeImageSnapshot = (
+        rect?: SkRect,
+        encodingOptions?: ImageSnapshotEncodingOptions,
+    ): SkiaDrawSnapshot | undefined => {
         const skImage = skiaCanvasRef.current?.makeImageSnapshot(rect) ?? undefined;
         if (skImage === undefined) return undefined;
-        const b64Data = skImage.encodeToBase64();
-        const uri = `data:image/png;base64,${b64Data}`;
+        const imageFormat = encodingOptions?.imageFormat ?? ImageFormat.PNG;
+        const b64Data = skImage.encodeToBase64(imageFormat, encodingOptions?.quality ?? 100);
+        const data = b64Data;
+        const uri = `data:${ImageFormatMimeTypeMap[imageFormat]};base64,${b64Data}`;
         const height = skImage.height() / 2;
         const width = skImage.width() / 2;
         return {
+            data,
             uri,
             height,
             width,

--- a/packages/skia-draw/src/hooks/useDrawHandle.ts
+++ b/packages/skia-draw/src/hooks/useDrawHandle.ts
@@ -1,9 +1,9 @@
+import { ImageFormat, SkiaDomView } from "@shopify/react-native-skia";
 import { ForwardedRef, MutableRefObject, RefObject, useImperativeHandle } from "react";
-import { ImageFormat, SkiaDomView, SkRect } from "@shopify/react-native-skia";
-import { useRerender } from "./useRerender";
 import { CanvasData } from "../Canvas/types";
 import { CanvasControls } from "../CanvasControlProvider";
-import { ImageSnapshotEncodingOptions, SkiaDrawSnapshot } from "../types";
+import { ImageSnapshotConfig, SkiaDrawSnapshot } from "../types";
+import { useRerender } from "./useRerender";
 
 const ImageFormatMimeTypeMap: Record<ImageFormat, string> = {
     [ImageFormat.JPEG]: "image/jpeg",
@@ -37,14 +37,11 @@ export const useCanvasControlHandle = (
         rerender();
     };
 
-    const makeImageSnapshot = (
-        rect?: SkRect,
-        encodingOptions?: ImageSnapshotEncodingOptions,
-    ): SkiaDrawSnapshot | undefined => {
-        const skImage = skiaCanvasRef.current?.makeImageSnapshot(rect) ?? undefined;
+    const makeImageSnapshot = (config?: ImageSnapshotConfig): SkiaDrawSnapshot | undefined => {
+        const skImage = skiaCanvasRef.current?.makeImageSnapshot(config?.rect) ?? undefined;
         if (skImage === undefined) return undefined;
-        const imageFormat = encodingOptions?.imageFormat ?? ImageFormat.PNG;
-        const b64Data = skImage.encodeToBase64(imageFormat, encodingOptions?.quality ?? 100);
+        const imageFormat = config?.imageFormat ?? ImageFormat.PNG;
+        const b64Data = skImage.encodeToBase64(imageFormat, config?.quality ?? 100);
         const data = b64Data;
         const uri = `data:${ImageFormatMimeTypeMap[imageFormat]};base64,${b64Data}`;
         const height = skImage.height() / 2;

--- a/packages/skia-draw/src/premades/ImageMarkup/ImageMarkup.tsx
+++ b/packages/skia-draw/src/premades/ImageMarkup/ImageMarkup.tsx
@@ -2,7 +2,7 @@ import { View, StyleSheet, ViewProps, KeyboardAvoidingView } from "react-native"
 import { Canvas } from "../../Canvas/Canvas";
 import { EDSControlPanel } from "./EDSControlPanel";
 import React, { useImperativeHandle, useMemo, useRef, useState, forwardRef } from "react";
-import { useImage, Image as SKImage } from "@shopify/react-native-skia";
+import { useImage, Image as SKImage, SkRect } from "@shopify/react-native-skia";
 import {
     CanvasControlProvider,
     CanvasControls,
@@ -24,7 +24,8 @@ export const ImageMarkup = forwardRef<CanvasImageControls, ImageMarkupProps>((pr
     const canvasRef = useRef<CanvasControls>(null);
 
     useImperativeHandle(ref, () => ({
-        makeImageSnapshot: () => canvasRef.current?.makeImageSnapshot() ?? undefined,
+        makeImageSnapshot: (rect?: SkRect, encodingOptions?: ImageEncodeOptions) =>
+            canvasRef.current?.makeImageSnapshot(rect, encodingOptions) ?? undefined,
     }));
 
     const image = useImage(props.markupImage);

--- a/packages/skia-draw/src/premades/ImageMarkup/ImageMarkup.tsx
+++ b/packages/skia-draw/src/premades/ImageMarkup/ImageMarkup.tsx
@@ -1,13 +1,14 @@
-import { View, StyleSheet, ViewProps, KeyboardAvoidingView } from "react-native";
+import { Image as SKImage, useImage } from "@shopify/react-native-skia";
+import React, { forwardRef, useImperativeHandle, useMemo, useRef, useState } from "react";
+import { KeyboardAvoidingView, StyleSheet, View, ViewProps } from "react-native";
 import { Canvas } from "../../Canvas/Canvas";
-import { EDSControlPanel } from "./EDSControlPanel";
-import React, { useImperativeHandle, useMemo, useRef, useState, forwardRef } from "react";
-import { useImage, Image as SKImage, SkRect } from "@shopify/react-native-skia";
 import {
     CanvasControlProvider,
     CanvasControls,
     CanvasImageControls,
 } from "../../CanvasControlProvider";
+import { ImageSnapshotConfig } from "../../types";
+import { EDSControlPanel } from "./EDSControlPanel";
 
 export type ImageMarkupProps = {
     markupImage?: string;
@@ -24,8 +25,8 @@ export const ImageMarkup = forwardRef<CanvasImageControls, ImageMarkupProps>((pr
     const canvasRef = useRef<CanvasControls>(null);
 
     useImperativeHandle(ref, () => ({
-        makeImageSnapshot: (rect?: SkRect, encodingOptions?: ImageEncodeOptions) =>
-            canvasRef.current?.makeImageSnapshot(rect, encodingOptions) ?? undefined,
+        makeImageSnapshot: (config?: ImageSnapshotConfig) =>
+            canvasRef.current?.makeImageSnapshot(config) ?? undefined,
     }));
 
     const image = useImage(props.markupImage);

--- a/packages/skia-draw/src/premades/SignaturePad/SignaturePad.tsx
+++ b/packages/skia-draw/src/premades/SignaturePad/SignaturePad.tsx
@@ -13,8 +13,8 @@ import {
 export const SignaturePad = forwardRef<CanvasImageControls, SignaturePadProps>((props, ref) => {
     const canvasRef = useRef<CanvasControls>(null);
     useImperativeHandle(ref, () => ({
-        makeImageSnapshot: (rect?: SkRect) =>
-            canvasRef.current?.makeImageSnapshot(rect) ?? undefined,
+        makeImageSnapshot: (rect?: SkRect, encodingOptions?: ImageEncodeOptions) =>
+            canvasRef.current?.makeImageSnapshot(rect, encodingOptions) ?? undefined,
     }));
     const canvasStyle = StyleSheet.flatten([styles.canvas, { height: props.height ?? 200 }]);
 

--- a/packages/skia-draw/src/premades/SignaturePad/SignaturePad.tsx
+++ b/packages/skia-draw/src/premades/SignaturePad/SignaturePad.tsx
@@ -1,20 +1,19 @@
-import React, { forwardRef, useImperativeHandle, useRef } from "react";
-import { Canvas } from "../../Canvas/Canvas";
-import { SignaturePadProps } from "../../types";
-import { View, StyleSheet, Text } from "react-native";
-import { SkRect } from "@shopify/react-native-skia";
 import { Button } from "@equinor/mad-components";
+import React, { forwardRef, useImperativeHandle, useRef } from "react";
+import { StyleSheet, Text, View } from "react-native";
+import { Canvas } from "../../Canvas/Canvas";
 import {
     CanvasControlProvider,
     CanvasControls,
     CanvasImageControls,
 } from "../../CanvasControlProvider";
+import { ImageSnapshotConfig, SignaturePadProps } from "../../types";
 
 export const SignaturePad = forwardRef<CanvasImageControls, SignaturePadProps>((props, ref) => {
     const canvasRef = useRef<CanvasControls>(null);
     useImperativeHandle(ref, () => ({
-        makeImageSnapshot: (rect?: SkRect, encodingOptions?: ImageEncodeOptions) =>
-            canvasRef.current?.makeImageSnapshot(rect, encodingOptions) ?? undefined,
+        makeImageSnapshot: (config?: ImageSnapshotConfig) =>
+            canvasRef.current?.makeImageSnapshot(config) ?? undefined,
     }));
     const canvasStyle = StyleSheet.flatten([styles.canvas, { height: props.height ?? 200 }]);
 

--- a/packages/skia-draw/src/types.ts
+++ b/packages/skia-draw/src/types.ts
@@ -1,13 +1,23 @@
 import { StyleProp, ViewProps, ViewStyle } from "react-native";
 import { PropsWithChildren } from "react";
+import { ImageFormat } from "@shopify/react-native-skia";
 
 export type SkiaDrawSnapshot = {
     /**
-     * URI containing Base64 data. Can be used with React Native's Image component
+     * Data URL containing metadata and base64 data. Can be used with React Native's Image component
      */
     uri: string;
-
+    /**
+     * Raw base64 data. Suitable for storing the image
+     */
+    data: string;
+    /**
+     * Height of the image in pixels
+     */
     height: number;
+    /**
+     * Width of the image in pixels
+     */
     width: number;
 };
 
@@ -25,4 +35,18 @@ export type CanvasProps = {
 
     style?: StyleProp<ViewStyle>;
     onLayout?: ViewProps["onLayout"];
+};
+
+/**
+ * Options object for configuring how the {@linkcode makeImageSnapshot} method encodes the resulting image.
+ */
+export type ImageSnapshotEncodingOptions = {
+    /**
+     * The format to encode the image in. Defaults to PNG.
+     */
+    imageFormat?: ImageFormat;
+    /**
+     * A value from 0 to 100. 100 is the least lossy. May be ignored.
+     */
+    quality?: number;
 };

--- a/packages/skia-draw/src/types.ts
+++ b/packages/skia-draw/src/types.ts
@@ -1,6 +1,6 @@
 import { StyleProp, ViewProps, ViewStyle } from "react-native";
 import { PropsWithChildren } from "react";
-import { ImageFormat } from "@shopify/react-native-skia";
+import { ImageFormat, SkRect } from "@shopify/react-native-skia";
 
 export type SkiaDrawSnapshot = {
     /**
@@ -38,9 +38,13 @@ export type CanvasProps = {
 };
 
 /**
- * Options object for configuring how the {@linkcode makeImageSnapshot} method encodes the resulting image.
+ * Options object for configuring how the {@linkcode makeImageSnapshot} method takes and encodes the current canvas state.
  */
-export type ImageSnapshotEncodingOptions = {
+export type ImageSnapshotConfig = {
+    /**
+     * The rectangle to capture. If omitted, the entire canvas will be captured.
+     */
+    rect?: SkRect;
     /**
      * The format to encode the image in. Defaults to PNG.
      */


### PR DESCRIPTION
- Add `encodingOptions` parameter to `makeImageSnapshot` method
- Add `data` field in `makeImageSnapshot` method that only contains base64 image data

closes #595 