### PR TITLE
fix(cell): use gesture handler when the cell i swipeable

### DIFF
--- a/.changeset/four-owls-bow.md
+++ b/.changeset/four-owls-bow.md
@@ -1,0 +1,6 @@
+---
+"@equinor/mad-components": patch
+---
+
+Adjusted the `Cell` component. Instead of using `PressableHighlight`, it now uses a different press
+component from `react-native-gesture-handler` when the cell is `swipeable`.

--- a/.changeset/giant-clouds-bow.md
+++ b/.changeset/giant-clouds-bow.md
@@ -1,0 +1,6 @@
+---
+"@equinor/mad-components": patch
+---
+
+Fix issue in the `Cell` component where cells with `additionalSurface` were incorrectly displayed in
+`Cell.Groups`. The divider was not fully streched out.

--- a/packages/components/src/components/Cell/Cell.tsx
+++ b/packages/components/src/components/Cell/Cell.tsx
@@ -75,7 +75,7 @@ export const Cell = forwardRef<View, React.PropsWithChildren<CellProps>>(
 
         const swipeable = !!leftSwipeGroup || !!rightSwipeGroup;
 
-        const CellContent = () => (
+        const cellContent = () => (
             <>
                 <View style={styles.contentContainer}>
                     {leftAdornment && <View style={styles.adornment}>{leftAdornment}</View>}
@@ -93,7 +93,7 @@ export const Cell = forwardRef<View, React.PropsWithChildren<CellProps>>(
             </>
         );
 
-        const Cell = () => (
+        const renderCell = () => (
             <View {...rest} style={[styles.container, rest.style]} ref={ref}>
                 <View style={{ flexDirection: "row" }}>
                     {additionalSurface && (
@@ -122,11 +122,11 @@ export const Cell = forwardRef<View, React.PropsWithChildren<CellProps>>(
                                 onPressOut={handlePressOut}
                                 onPress={onPress}
                             >
-                                <CellContent />
+                                {cellContent()}
                             </TouchableWithoutFeedback>
                         ) : (
                             <PressableHighlight disabled={!onPress} onPress={onPress}>
-                                <CellContent />
+                                {cellContent()}
                             </PressableHighlight>
                         )}
                     </Animated.View>
@@ -152,10 +152,10 @@ export const Cell = forwardRef<View, React.PropsWithChildren<CellProps>>(
                     ))
                 }
             >
-                <Cell />
+                {renderCell()}
             </SwipeableWithContext>
         ) : (
-            <Cell />
+            renderCell()
         );
     },
 );

--- a/packages/components/src/components/Cell/Cell.tsx
+++ b/packages/components/src/components/Cell/Cell.tsx
@@ -24,6 +24,7 @@ export type AdditionalSurfaceProps = {
 };
 
 type SwipeGroup = CellSwipeItemProps[];
+
 export type CellProps = {
     /**
      * A component that uses the left-remaining space after the child content of the cell has been adjusted for.
@@ -75,6 +76,24 @@ export const Cell = forwardRef<View, React.PropsWithChildren<CellProps>>(
         const swipeable = !!leftSwipeGroup || !!rightSwipeGroup;
 
         const CellContent = () => (
+            <>
+                <View style={styles.contentContainer}>
+                    {leftAdornment && <View style={styles.adornment}>{leftAdornment}</View>}
+
+                    <View style={styles.children}>
+                        <View style={{ flex: 1, justifyContent: "center" }}>{children}</View>
+                    </View>
+                    {rightAdornment && <View style={styles.adornment}>{rightAdornment}</View>}
+                </View>
+                {!isLastCell && (
+                    <View style={styles.dividerOuter}>
+                        <View style={styles.dividerInner} />
+                    </View>
+                )}
+            </>
+        );
+
+        const Cell = () => (
             <View {...rest} style={[styles.container, rest.style]} ref={ref}>
                 <View style={{ flexDirection: "row" }}>
                     {additionalSurface && (
@@ -86,35 +105,30 @@ export const Cell = forwardRef<View, React.PropsWithChildren<CellProps>>(
                                 {additionalSurface.component}
                             </PressableHighlight>
                             <View style={styles.verticalLine} />
-                        </>
-                    )}
-                    <Animated.View style={[animatedStyle, { flex: 1 }]}>
-                        <TouchableWithoutFeedback
-                            disabled={!onPress}
-                            onPressIn={handlePressIn}
-                            onPressOut={handlePressOut}
-                            onPress={onPress}
-                        >
-                            <View style={styles.contentContainer}>
-                                {leftAdornment && (
-                                    <View style={styles.adornment}>{leftAdornment}</View>
-                                )}
 
-                                <View style={styles.children}>
-                                    <View style={{ flex: 1, justifyContent: "center" }}>
-                                        {children}
-                                    </View>
-                                </View>
-                                {rightAdornment && (
-                                    <View style={styles.adornment}>{rightAdornment}</View>
-                                )}
-                            </View>
                             {!isLastCell && (
                                 <View style={styles.dividerOuter}>
                                     <View style={styles.dividerInner} />
                                 </View>
                             )}
-                        </TouchableWithoutFeedback>
+                        </>
+                    )}
+
+                    <Animated.View style={[animatedStyle, { flex: 1 }]}>
+                        {swipeable ? (
+                            <TouchableWithoutFeedback
+                                disabled={!onPress}
+                                onPressIn={handlePressIn}
+                                onPressOut={handlePressOut}
+                                onPress={onPress}
+                            >
+                                <CellContent />
+                            </TouchableWithoutFeedback>
+                        ) : (
+                            <PressableHighlight disabled={!onPress} onPress={onPress}>
+                                <CellContent />
+                            </PressableHighlight>
+                        )}
                     </Animated.View>
                 </View>
             </View>
@@ -138,10 +152,10 @@ export const Cell = forwardRef<View, React.PropsWithChildren<CellProps>>(
                     ))
                 }
             >
-                {CellContent()}
+                <Cell />
             </SwipeableWithContext>
         ) : (
-            CellContent()
+            <Cell />
         );
     },
 );
@@ -183,8 +197,7 @@ const themeStyle = EDSStyleSheet.create((theme, props: CellGroupContextType) => 
         alignItems: "center",
     },
     verticalLine: {
-        borderRightWidth: 1,
-        borderStyle: "solid",
+        borderRightWidth: theme.geometry.border.borderWidth,
         borderColor: theme.colors.border.medium,
         marginVertical: theme.spacing.menu.item.paddingVertical,
     },

--- a/packages/components/src/components/PressableHighlight/PressableHighlight.tsx
+++ b/packages/components/src/components/PressableHighlight/PressableHighlight.tsx
@@ -1,6 +1,5 @@
 import React, { forwardRef } from "react";
 import { Pressable, PressableProps, StyleSheet, View, ViewStyle } from "react-native";
-import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated from "react-native-reanimated";
 import { useFadeAnimation } from "../../styling/animations";
 import { DisabledPressable } from "./DisabledPressable";
@@ -33,25 +32,22 @@ export const PressableHighlight = forwardRef<
         ref,
     ) => {
         const { handlePressIn, handlePressOut, animatedStyle } = useFadeAnimation();
-        const tap = Gesture.Tap();
 
         const PressableComponent = disabled ? DisabledPressable : Pressable;
 
         return (
-            <GestureDetector gesture={tap}>
-                <PressableComponent
-                    {...rest}
-                    ref={ref}
-                    style={style}
-                    onPressIn={event => !disabled && (handlePressIn(), rest.onPressIn?.(event))}
-                    onPressOut={event => !disabled && (handlePressOut(), rest.onPressOut?.(event))}
-                    onPress={event => !disabled && !!onPress && onPress(event)}
-                    disabled={disabled}
-                >
-                    <Animated.View style={[animatedStyle, styles.overlay]} />
-                    {children}
-                </PressableComponent>
-            </GestureDetector>
+            <PressableComponent
+                {...rest}
+                ref={ref}
+                style={style}
+                onPressIn={event => !disabled && (handlePressIn(), rest.onPressIn?.(event))}
+                onPressOut={event => !disabled && (handlePressOut(), rest.onPressOut?.(event))}
+                onPress={event => !disabled && !!onPress && onPress(event)}
+                disabled={disabled}
+            >
+                <Animated.View style={[animatedStyle, styles.overlay]} />
+                {children}
+            </PressableComponent>
         );
     },
 );


### PR DESCRIPTION
**Key changes:**
- Replaced `PressableHighlight` with `TouchableWithoutFeedback` when the cell is swipable
- Fixed bug where the divider in Cell.Group was cropped if you have a cell with `additionalSurface` prop.

Fixes: #607 