### PR TITLE
fix(workordercell): improve component and fix deviations

### DIFF
--- a/.changeset/tricky-deers-argue.md
+++ b/.changeset/tricky-deers-argue.md
@@ -1,0 +1,7 @@
+---
+"@equinor/mad-dfw": minor
+---
+
+WorkOrderCell adjusted. Renamed prop `workOrder` to `workOrderId`. Added new prop, `workOrderType`,
+this relates to the workOrderId. Removed the `symbolDirection` and `overwriteLabel` props. The
+symbol direction is now column by default.

--- a/apps/chronicles/screens/dfw/dfwcomponents/WorkOrderCellScreen.tsx
+++ b/apps/chronicles/screens/dfw/dfwcomponents/WorkOrderCellScreen.tsx
@@ -24,7 +24,8 @@ export const WorkOrderCellScreen = () => {
             <Spacer />
             <WorkOrderCell
                 title="Work Order Cell"
-                workOrder="25282760"
+                workOrderId="25282760"
+                workOrderType="PM02"
                 maintenanceType="Surface monitoring"
                 functionalLocation="TAG-123456"
                 equipment="EQUIP-123456"
@@ -37,6 +38,7 @@ export const WorkOrderCellScreen = () => {
                 isProductionCritical
                 startJobButton={{
                     visible: true,
+                    loading: true,
                     onPress: () => console.log("Start"),
                 }}
                 readyForOperationButton={{
@@ -60,7 +62,8 @@ export const WorkOrderCellScreen = () => {
             <Spacer />
             <WorkOrderCell
                 title="Work Order Cell"
-                workOrder="25282760"
+                workOrderId="25282760"
+                workOrderType="PM02"
                 maintenanceType="Surface monitoring"
                 functionalLocation="TAG-123456"
                 equipment="EQUIP-123456"
@@ -82,7 +85,6 @@ export const WorkOrderCellScreen = () => {
                     onPress: () => console.log("Complete"),
                 }}
                 showSymbols
-                symbolDirection="row"
             />
             <Spacer />
             <View style={styles.readableContent}>
@@ -94,7 +96,8 @@ export const WorkOrderCellScreen = () => {
             <Spacer />
             <WorkOrderCell.Navigation
                 title="Work Order Cell"
-                workOrder="25282760"
+                workOrderId="25282760"
+                workOrderType="PM02"
                 maintenanceType="Surface monitoring"
                 functionalLocation="TAG-123456"
                 equipment="EQUIP-123456"
@@ -117,10 +120,12 @@ export const WorkOrderCellScreen = () => {
             <Spacer />
             <WorkOrderCell
                 title="Basic Work Order Cell"
-                workOrder="25282760"
+                workOrderId="25282760"
+                workOrderType="PM02"
                 maintenanceType="Surface monitoring"
                 functionalLocation="TAG-123456"
                 valueColor="danger"
+                showSymbols={false}
             />
         </ScrollView>
     );

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/PropertyList.tsx
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/PropertyList.tsx
@@ -21,13 +21,13 @@ type PropertyListProps = {
     valueColor: Color;
 };
 
-export const PropertyList = ({ data: workOrder, valueColor }: PropertyListProps) => {
+export const PropertyList = ({ data, valueColor }: PropertyListProps) => {
     const currentDate = new Date();
-    const requiredEnd = workOrder.requiredEnd ? new Date(workOrder.requiredEnd) : null;
+    const requiredEnd = data.requiredEnd ? new Date(data.requiredEnd) : null;
 
     const combinedDates =
-        workOrder.basicStartDate && workOrder.basicFinishDate
-            ? `${formatDate(workOrder.basicStartDate)} - ${formatDate(workOrder.basicFinishDate)}`
+        data.basicStartDate && data.basicFinishDate
+            ? `${formatDate(data.basicStartDate)} - ${formatDate(data.basicFinishDate)}`
             : null;
 
     const getLabel = (key: string) => {
@@ -49,7 +49,7 @@ export const PropertyList = ({ data: workOrder, valueColor }: PropertyListProps)
 
     return (
         <>
-            {Object.entries(workOrder).map(([key, value], index) => {
+            {Object.entries(data).map(([key, value], index) => {
                 const typedKey = key as keyof WorkOrder;
 
                 if (combinedDates && typedKey === "basicFinishDate") return null;

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/PropertyList.tsx
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/PropertyList.tsx
@@ -1,12 +1,11 @@
+import { Color } from "@equinor/mad-components";
 import React from "react";
 import { PropertyRow } from "../PropertyRow";
 import { WorkOrder } from "./types";
-import moment from "moment";
-import { Color, useToken } from "@equinor/mad-components";
+import { formatDate } from "./utils";
 
-const defaultWorkOrderLabelMap: Record<keyof WorkOrder, string> = {
+const workOrderLabelMap: Record<string, string | undefined> = {
     title: "Title",
-    workOrder: "Work order",
     maintenanceType: "Maintenance type",
     functionalLocation: "Functional Location",
     equipment: "Equipment",
@@ -18,22 +17,12 @@ const defaultWorkOrderLabelMap: Record<keyof WorkOrder, string> = {
 } as const;
 
 type PropertyListProps = {
-    workOrder: Partial<WorkOrder>;
+    data: Partial<WorkOrder>;
     valueColor: Color;
-    currentDate: Date;
-    overwriteLabel?: Partial<Record<keyof WorkOrder, string>>;
 };
 
-export const PropertyList = ({
-    workOrder,
-    valueColor,
-    currentDate,
-    overwriteLabel = {},
-}: PropertyListProps) => {
-    const token = useToken();
-
-    const formatDate = (dateString: string) => moment(dateString).format("DD.MM.YYYY");
-
+export const PropertyList = ({ data: workOrder, valueColor }: PropertyListProps) => {
+    const currentDate = new Date();
     const requiredEnd = workOrder.requiredEnd ? new Date(workOrder.requiredEnd) : null;
 
     const combinedDates =
@@ -41,11 +30,11 @@ export const PropertyList = ({
             ? `${formatDate(workOrder.basicStartDate)} - ${formatDate(workOrder.basicFinishDate)}`
             : null;
 
-    const getLabel = (key: keyof WorkOrder) => {
+    const getLabel = (key: string) => {
         if (key === "basicStartDate" && combinedDates) {
             return "Basic start / finish";
         }
-        return overwriteLabel?.[key] ?? defaultWorkOrderLabelMap[key];
+        return workOrderLabelMap[key];
     };
 
     const getDisplayValue = (key: keyof WorkOrder, value: string | undefined) => {
@@ -64,7 +53,6 @@ export const PropertyList = ({
                 const typedKey = key as keyof WorkOrder;
 
                 if (combinedDates && typedKey === "basicFinishDate") return null;
-
                 if (value || (typedKey === "basicStartDate" && combinedDates)) {
                     const label = getLabel(typedKey);
                     const displayValue = getDisplayValue(typedKey, value);
@@ -75,13 +63,14 @@ export const PropertyList = ({
                             : valueColor;
 
                     return (
-                        <PropertyRow
-                            key={index}
-                            label={label}
-                            value={displayValue ?? ""}
-                            style={{ marginBottom: token.spacing.cell.group.titleBottomPadding }}
-                            textColor={textColor}
-                        />
+                        label && (
+                            <PropertyRow
+                                key={index}
+                                label={label}
+                                value={displayValue ?? ""}
+                                textColor={textColor}
+                            />
+                        )
                     );
                 }
                 return null;

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCellNavigation.tsx
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCellNavigation.tsx
@@ -1,7 +1,7 @@
-import { Cell, EDSStyleSheet, Icon, Label, Typography, useStyles } from "@equinor/mad-components";
-import moment from "moment";
+import { Cell, EDSStyleSheet, Icon, Typography, useStyles } from "@equinor/mad-components";
 import React, { useMemo } from "react";
 import { View } from "react-native";
+import { PropertyRow } from "../PropertyRow";
 import { PropertyList } from "./PropertyList";
 import { StatusIcon } from "./StatusIcon";
 import { WorkOrderCellProps } from "./types";
@@ -13,19 +13,20 @@ type WorkOrderCellNavigationProps = WorkOrderCellProps & {
 
 export const WorkOrderCellNavigation = ({
     title,
+    workOrderId,
+    workOrderType,
     maintenanceType,
     valueColor = "textTertiary",
     isHseCritical,
     isProductionCritical,
     showSymbols = true,
-    overwriteLabel,
     onPress,
     style,
     ...rest
 }: WorkOrderCellNavigationProps) => {
     const styles = useStyles(themeStyles);
 
-    const currentDate = moment();
+    const currentDate = useMemo(() => new Date(), []);
     const iconsAndLabels = useMemo(
         () =>
             getStatusIconsAndLabels(
@@ -45,13 +46,13 @@ export const WorkOrderCellNavigation = ({
                     <Typography numberOfLines={1} variant="h5" bold style={styles.title}>
                         {title}
                     </Typography>
-                    {maintenanceType && <Label label={maintenanceType} style={styles.label} />}
-                    <PropertyList
-                        workOrder={rest}
-                        overwriteLabel={overwriteLabel}
-                        valueColor={valueColor}
-                        currentDate={currentDate.toDate()}
-                    />
+                    <View style={styles.dataContainer}>
+                        <Typography group="paragraph" variant="body_short" color="textTertiary">
+                            {maintenanceType}
+                        </Typography>
+                        <PropertyRow label={workOrderType} value={workOrderId} />
+                        <PropertyList data={rest} valueColor={valueColor} />
+                    </View>
                 </View>
                 {showSymbols && (
                     <View style={styles.iconListContainer}>
@@ -79,8 +80,8 @@ const themeStyles = EDSStyleSheet.create(theme => ({
     title: {
         marginBottom: theme.spacing.container.paddingVertical,
     },
-    label: {
-        marginBottom: theme.spacing.cell.group.titleBottomPadding,
+    dataContainer: {
+        gap: theme.spacing.cell.group.titleBottomPadding,
     },
     iconListContainer: {
         position: "absolute",

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/index.ts
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/index.ts
@@ -1,6 +1,6 @@
 import { WorkOrderCell as _WorkOrderCell } from "./WorkOrderCell";
 import { WorkOrderCellNavigation } from "./WorkOrderCellNavigation";
-import { WorkOrder, WorkOrderCellProps, StatusConfig } from "./types";
+import { WorkOrder, WorkOrderType, WorkOrderCellProps, StatusConfig } from "./types";
 
 type WorkOrderCellFamily = typeof _WorkOrderCell & {
     Navigation: typeof WorkOrderCellNavigation;
@@ -10,4 +10,4 @@ const WorkOrderCell = _WorkOrderCell as WorkOrderCellFamily;
 WorkOrderCell.Navigation = WorkOrderCellNavigation;
 
 export { WorkOrderCell };
-export type { WorkOrder, WorkOrderCellProps, StatusConfig };
+export type { WorkOrder, WorkOrderType, WorkOrderCellProps, StatusConfig };

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/types.ts
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/types.ts
@@ -1,9 +1,21 @@
 import { Color, IconName } from "@equinor/mad-components";
 import { ViewProps } from "react-native";
 
+export type WorkOrderType =
+    | "PM01"
+    | "PM02"
+    | "PM03"
+    | "PM04"
+    | "PM05"
+    | "PM06"
+    | "PM10"
+    | "PM15"
+    | "PM20";
+
 export type WorkOrder = {
+    workOrderId: string;
+    workOrderType: WorkOrderType;
     title: string;
-    workOrder: string;
     maintenanceType?: string;
     equipment?: string;
     activeStatus?: string;
@@ -22,8 +34,9 @@ type ButtonOptions = {
 };
 
 export type WorkOrderCellProps = {
+    workOrderId: string;
+    workOrderType: WorkOrderType;
     showSymbols?: boolean;
-    symbolDirection?: "column" | "row";
     valueColor?: Color;
     isHseCritical?: boolean;
     isProductionCritical?: boolean;

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/utils.ts
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/utils.ts
@@ -1,15 +1,7 @@
-import moment from "moment";
 import { StatusConfig } from "./types";
 
 export const getStatusIconConfig = (status: string): StatusConfig | undefined => {
     switch (status) {
-        case "RDEX":
-            return {
-                icon: "circle-outline",
-                label: "Ready for execution",
-                textColor: "textTertiary",
-                iconColor: "textPrimary",
-            };
         case "STRT":
             return {
                 icon: "circle-half-full",
@@ -31,11 +23,11 @@ export const getStatusIconConfig = (status: string): StatusConfig | undefined =>
 export const getStatusIconsAndLabels = (
     activeStatusIds: string | undefined,
     requiredEndDate: string | null,
-    currentDate: moment.Moment,
+    currentDate: Date,
     hseCritical?: boolean,
     productionCritical?: boolean,
 ): StatusConfig[] => {
-    const requiredEnd = requiredEndDate ? moment(requiredEndDate) : null;
+    const requiredEnd = requiredEndDate ? new Date(requiredEndDate) : null;
     const activeStatuses = activeStatusIds?.split(" ");
 
     const iconsAndLabels: StatusConfig[] = [];
@@ -67,6 +59,15 @@ export const getStatusIconsAndLabels = (
         });
     }
 
+    if (!activeStatuses?.includes("STRT")) {
+        iconsAndLabels.push({
+            icon: "circle-outline",
+            label: "Not started",
+            textColor: "textTertiary",
+            iconColor: "textPrimary",
+        });
+    }
+
     activeStatuses?.forEach(status => {
         const statusConfig = getStatusIconConfig(status);
         if (statusConfig) {
@@ -75,4 +76,10 @@ export const getStatusIconsAndLabels = (
     });
 
     return iconsAndLabels;
+};
+
+export const formatDate = (dateString: string): string => {
+    const date = new Date(dateString);
+    // DD.MM.YYYY
+    return date.toLocaleDateString("en-GB").replace(/\//g, ".");
 };


### PR DESCRIPTION
***Key changes:***

- Replaced moment with Date.
- Removed the `Ready for execution` icon and label. 
- If the status do not include STRT it should show a new label and icon.
- Simplified the component, remove unnecessary props and logic.
       - Renamed the workOrder prop to workOrderId.
       - Add new prop, workOrderType.
       - remove the symbolDirection prop. Symbols should only be displayed in column.
       
 Fixes: #622