### PR TITLE
fix(workordercell): remove excess padding and add work order type

### DIFF
--- a/.changeset/tough-days-drum.md
+++ b/.changeset/tough-days-drum.md
@@ -1,0 +1,6 @@
+---
+"@equinor/mad-dfw": patch
+---
+
+Added new value to the `WorkOrderType`. Prevent excess padding when the `maintenanceType` is not
+being used.

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCell.tsx
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCell.tsx
@@ -69,9 +69,11 @@ export const WorkOrderCell = ({
                 </View>
             )}
             <View style={styles.dataContainer}>
-                <Typography group="paragraph" variant="body_short" color="textTertiary">
-                    {maintenanceType}
-                </Typography>
+                {maintenanceType && (
+                    <Typography group="paragraph" variant="body_short" color="textTertiary">
+                        {maintenanceType}
+                    </Typography>
+                )}
                 <PropertyRow label={workOrderType} value={workOrderId} />
                 <PropertyList data={rest} valueColor={valueColor} />
             </View>

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCellNavigation.tsx
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCellNavigation.tsx
@@ -47,9 +47,11 @@ export const WorkOrderCellNavigation = ({
                         {title}
                     </Typography>
                     <View style={styles.dataContainer}>
-                        <Typography group="paragraph" variant="body_short" color="textTertiary">
-                            {maintenanceType}
-                        </Typography>
+                        {maintenanceType && (
+                            <Typography group="paragraph" variant="body_short" color="textTertiary">
+                                {maintenanceType}
+                            </Typography>
+                        )}
                         <PropertyRow label={workOrderType} value={workOrderId} />
                         <PropertyList data={rest} valueColor={valueColor} />
                     </View>

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/types.ts
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/types.ts
@@ -10,7 +10,8 @@ export type WorkOrderType =
     | "PM06"
     | "PM10"
     | "PM15"
-    | "PM20";
+    | "PM20"
+    | "Unknown";
 
 export type WorkOrder = {
     workOrderId: string;

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/types.ts
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/types.ts
@@ -11,7 +11,7 @@ export type WorkOrderType =
     | "PM10"
     | "PM15"
     | "PM20"
-    | "Unknown";
+    | "unknown";
 
 export type WorkOrder = {
     workOrderId: string;


### PR DESCRIPTION
**Key changes:**
- Added new value to the `WorkOrderType`, "unkown". 
- Fix padding issue for when the `maintenanceType` is not being used.

Fixes: #625 