### PR TITLE
feat(workordercell): make the navigation variant swipeable

### DIFF
--- a/.changeset/afraid-peaches-jam.md
+++ b/.changeset/afraid-peaches-jam.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-dfw": patch
+---
+
+The `WorkOrderCell.Navigation` component is now swipeable.

--- a/.changeset/kind-buckets-accept.md
+++ b/.changeset/kind-buckets-accept.md
@@ -1,0 +1,6 @@
+---
+"@equinor/mad-dfw": patch
+---
+
+New prop for `WorkOrderCell` components ,`additionalPropertyRows`: Adds custom rows to standard
+details.

--- a/.changeset/sour-forks-clap.md
+++ b/.changeset/sour-forks-clap.md
@@ -2,4 +2,4 @@
 "@equinor/mad-dfw": patch
 ---
 
-Added new value, `Operations from filter`, to the `WorkORderPropertyList`.
+Added new value, `Operations from filter`, to the `WorkOrderPropertyList`.

--- a/.changeset/sour-forks-clap.md
+++ b/.changeset/sour-forks-clap.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-dfw": patch
+---
+
+Added new value, `Operations from filter`, to the `WorkORderPropertyList`.

--- a/apps/chronicles/screens/dfw/dfwcomponents/WorkOrderCellScreen.tsx
+++ b/apps/chronicles/screens/dfw/dfwcomponents/WorkOrderCellScreen.tsx
@@ -129,6 +129,16 @@ export const WorkOrderCellScreen = () => {
                         basicStartDate: "2023-04-07",
                         basicEndDate: "2023-09-12",
                     }}
+                    additionalPropertyRows={[
+                        {
+                            label: "Additional Label 1",
+                            value: "Additional Value 1",
+                        },
+                        {
+                            label: "Additional Label 2",
+                            value: "Additional Value 2",
+                        },
+                    ]}
                 />
             </View>
             <Spacer />

--- a/apps/chronicles/screens/dfw/dfwcomponents/WorkOrderCellScreen.tsx
+++ b/apps/chronicles/screens/dfw/dfwcomponents/WorkOrderCellScreen.tsx
@@ -155,6 +155,38 @@ export const WorkOrderCellScreen = () => {
                 }}
                 onPress={() => console.log("Pressed")}
             />
+            <Spacer />
+            <View style={styles.readableContent}>
+                <Typography>The WorkOrderCell.Navigation can also be swipeable.</Typography>
+            </View>
+            <Spacer />
+            <WorkOrderCell.Navigation
+                workOrder={{
+                    title: "Work Order Cell",
+                    workOrderId: "25282760",
+                    workOrderType: "PM02",
+                    tagId: "TAG-123456",
+                    activeStatusIds: "STRT",
+                    basicStartDate: "2023-02-07",
+                    basicEndDate: "2023-04-07",
+                    workCenterId: "POMISP",
+                    isHseCritical: true,
+                    isProductionCritical: true,
+                }}
+                onPress={() => console.log("Pressed")}
+                leftSwipeGroup={[
+                    {
+                        title: "Left side here",
+                        color: "success",
+                    },
+                ]}
+                rightSwipeGroup={[
+                    {
+                        title: "Right side here",
+                        color: "primary",
+                    },
+                ]}
+            />
         </ScrollView>
     );
 };

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCell.tsx
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCell.tsx
@@ -20,6 +20,7 @@ export const WorkOrderCell = ({
     readyForOperationButton,
     tecoButton,
     workOrder,
+    additionalPropertyRows = [],
     ...rest
 }: WorkOrderCellProps) => {
     const breakpoint = useBreakpoint();
@@ -63,7 +64,10 @@ export const WorkOrderCell = ({
                         {workOrder.maintenanceType}
                     </Typography>
                 )}
-                <WorkOrderPropertyList workOrder={workOrder} />
+                <WorkOrderPropertyList
+                    workOrder={workOrder}
+                    additionalPropertyRows={additionalPropertyRows}
+                />
             </View>
             {anyButtonVisible && (
                 <View

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCellNavigation.tsx
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCellNavigation.tsx
@@ -26,6 +26,7 @@ export const WorkOrderCellNavigation = ({
     workOrder,
     leftSwipeGroup,
     rightSwipeGroup,
+    additionalPropertyRows = [],
     onPress,
     ...rest
 }: WorkOrderCellNavigationProps) => {
@@ -60,7 +61,10 @@ export const WorkOrderCellNavigation = ({
                                 {workOrder.maintenanceType}
                             </Typography>
                         )}
-                        <WorkOrderPropertyList workOrder={workOrder} />
+                        <WorkOrderPropertyList
+                            workOrder={workOrder}
+                            additionalPropertyRows={additionalPropertyRows}
+                        />{" "}
                     </View>
                 </View>
                 {showSymbols && (

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCellNavigation.tsx
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCellNavigation.tsx
@@ -1,4 +1,11 @@
-import { Cell, EDSStyleSheet, Icon, Typography, useStyles } from "@equinor/mad-components";
+import {
+    Cell,
+    CellSwipeItemProps,
+    EDSStyleSheet,
+    Icon,
+    Typography,
+    useStyles,
+} from "@equinor/mad-components";
 import React, { useMemo } from "react";
 import { View } from "react-native";
 import { StatusIcon } from "./StatusIcon";
@@ -6,14 +13,20 @@ import { WorkOrderCellProps } from "./types";
 import { getStatusIconsAndLabels } from "./utils";
 import { WorkOrderPropertyList } from "./WorkOrderPropertyList";
 
+type SwipeGroup = CellSwipeItemProps[];
+
 type WorkOrderCellNavigationProps = WorkOrderCellProps & {
     onPress: () => void;
+    leftSwipeGroup?: SwipeGroup;
+    rightSwipeGroup?: SwipeGroup;
 };
 
 export const WorkOrderCellNavigation = ({
     showSymbols = true,
-    onPress,
     workOrder,
+    leftSwipeGroup,
+    rightSwipeGroup,
+    onPress,
     ...rest
 }: WorkOrderCellNavigationProps) => {
     const styles = useStyles(themeStyles);
@@ -30,7 +43,12 @@ export const WorkOrderCellNavigation = ({
     );
 
     return (
-        <Cell {...rest} onPress={onPress}>
+        <Cell
+            {...rest}
+            onPress={onPress}
+            leftSwipeGroup={leftSwipeGroup}
+            rightSwipeGroup={rightSwipeGroup}
+        >
             <View style={styles.container}>
                 <View style={styles.contentContainer}>
                     <Typography numberOfLines={1} variant="h5" bold style={styles.title}>

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderPropertyList.tsx
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderPropertyList.tsx
@@ -20,11 +20,6 @@ const propertyRowConfig: PropertyRowConfig = [
         condition: () => true,
     },
     {
-        label: "Functional Location",
-        value: wo => `${wo.tagPlantId}-${wo.tagId}`,
-        condition: wo => !!wo.tagId && !!wo.tagPlantId,
-    },
-    {
         label: "Tag",
         value: wo => wo.tagId!,
         condition: wo => !!wo.tagId && !wo.tagPlantId,
@@ -50,24 +45,34 @@ const propertyRowConfig: PropertyRowConfig = [
         value: wo => formatDate(wo.basicStartDate!),
         condition: wo => !!wo.basicStartDate && !wo.basicEndDate,
     },
-
     {
         label: "Basic finish",
         value: wo => formatDate(wo.basicEndDate!),
         condition: wo => !!wo.basicEndDate && !wo.basicStartDate,
     },
-
     {
         label: "Required end",
         value: wo => formatDate(wo.requiredEndDate!),
         color: wo => (new Date() > new Date(wo.requiredEndDate!) ? "danger" : "textTertiary"),
         condition: wo => !!wo.requiredEndDate,
     },
-
     {
         label: "Work center",
         value: wo => wo.workCenterId ?? "",
         condition: wo => !!wo.workCenterId,
+    },
+    {
+        label: "Functional location",
+        value: wo => `${wo.operationsFromFilter} operations`,
+        condition: wo => !!wo.tagId && !!wo.tagPlantId,
+    },
+    {
+        label: "Operations from filter",
+        value: wo =>
+            `${wo.operationsFromFilter} ${
+                wo.operationsFromFilter === 1 ? "operation" : "operations"
+            }`,
+        condition: wo => !!wo.operationsFromFilter,
     },
 ] as const;
 

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderPropertyList.tsx
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderPropertyList.tsx
@@ -1,7 +1,7 @@
 import { Color } from "@equinor/mad-components";
 import React from "react";
 import { PropertyRow } from "../PropertyRow";
-import { WorkOrder } from "./types";
+import { AdditionalPropertyRow, WorkOrder } from "./types";
 import { formatDate } from "./utils";
 
 type PropertyRowEntry = {
@@ -62,25 +62,21 @@ const propertyRowConfig: PropertyRowConfig = [
         condition: wo => !!wo.workCenterId,
     },
     {
-        label: "Functional location",
-        value: wo => `${wo.operationsFromFilter} operations`,
+        label: "Functional Location",
+        value: wo => `${wo.tagPlantId}-${wo.tagId}`,
         condition: wo => !!wo.tagId && !!wo.tagPlantId,
-    },
-    {
-        label: "Operations from filter",
-        value: wo =>
-            `${wo.operationsFromFilter} ${
-                wo.operationsFromFilter === 1 ? "operation" : "operations"
-            }`,
-        condition: wo => !!wo.operationsFromFilter,
     },
 ] as const;
 
 type WorkOrderPropertyListProps = {
     workOrder: WorkOrder;
+    additionalPropertyRows?: AdditionalPropertyRow[];
 };
 
-export const WorkOrderPropertyList = ({ workOrder }: WorkOrderPropertyListProps) => {
+export const WorkOrderPropertyList = ({
+    workOrder,
+    additionalPropertyRows = [],
+}: WorkOrderPropertyListProps) => {
     return (
         <>
             {propertyRowConfig.map(item => {
@@ -98,6 +94,10 @@ export const WorkOrderPropertyList = ({ workOrder }: WorkOrderPropertyListProps)
                     />
                 );
             })}
+
+            {additionalPropertyRows.map((item, index) => (
+                <PropertyRow key={`additional-${index}`} label={item.label} value={item.value} />
+            ))}
         </>
     );
 };

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderPropertyList.tsx
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderPropertyList.tsx
@@ -62,7 +62,7 @@ const propertyRowConfig: PropertyRowConfig = [
         condition: wo => !!wo.workCenterId,
     },
     {
-        label: "Functional Location",
+        label: "Functional location",
         value: wo => `${wo.tagPlantId}-${wo.tagId}`,
         condition: wo => !!wo.tagId && !!wo.tagPlantId,
     },

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/types.ts
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/types.ts
@@ -26,6 +26,7 @@ export type WorkOrder = {
     basicEndDate?: string;
     requiredEndDate?: string;
     workCenterId?: string;
+    operationsFromFilter: number;
     isHseCritical?: boolean;
     isProductionCritical?: boolean;
 };

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/types.ts
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/types.ts
@@ -1,6 +1,11 @@
 import { Color, IconName } from "@equinor/mad-components";
 import { ViewProps } from "react-native";
 
+export type AdditionalPropertyRow = {
+    label: string;
+    value: string;
+};
+
 export type WorkOrderType =
     | "PM01"
     | "PM02"
@@ -26,7 +31,6 @@ export type WorkOrder = {
     basicEndDate?: string;
     requiredEndDate?: string;
     workCenterId?: string;
-    operationsFromFilter: number;
     isHseCritical?: boolean;
     isProductionCritical?: boolean;
 };
@@ -59,6 +63,10 @@ export type WorkOrderCellProps = {
      * Work order data to display in the cell.
      */
     workOrder: WorkOrder;
+    /*
+     * Additional property rows to be displayed under the work order data
+     */
+    additionalPropertyRows?: AdditionalPropertyRow[];
 } & Omit<ViewProps, "children">;
 
 export type StatusConfig = {


### PR DESCRIPTION
**Key changes:**
- Make the `WorkOrderCell.Navigation` swipeable.
- Changed label `Functional Location` to `Functional location` and adjusted its position in the property list. According to Figma, it should be placed further down.
https://www.figma.com/design/S4NQWezdYGuVz5aAp4xAo4Bl/WorkOrders?node-id=29970-74977&node-type=canvas&t=7zBMgCSo3bSXpvLu-0 
- Added new value, `Operations from filter`,  to the `WorkOrderPropertyList`.

Fixes: #631