### PR TITLE
fix(workordercell): change the finish icon

### DIFF
--- a/.changeset/dry-rivers-begin.md
+++ b/.changeset/dry-rivers-begin.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-dfw": patch
+---
+
+Changed the finished icon in the `WorkOrderCell` from `circle` to `check-circle`

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/utils.ts
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/utils.ts
@@ -15,7 +15,7 @@ const getStatusIconConfig = (status: string): StatusConfig | undefined => {
             iconColor: "textPrimary",
         },
         finished: {
-            icon: "circle",
+            icon: "check-circle",
             label: "Finished",
             textColor: "textTertiary",
             iconColor: "textPrimary",


### PR DESCRIPTION
Changed the finished icon in the `WorkOrderCell` from `circle` to `check-circle`
