### PR TITLE
fix(workordercell): make text values wrap

### DIFF
--- a/.changeset/afraid-horses-drop.md
+++ b/.changeset/afraid-horses-drop.md
@@ -1,0 +1,6 @@
+---
+"@equinor/mad-dfw": patch
+---
+
+New prop, `wrapValues`, that wraps the text values in the `WorkOrderCell` and
+`WorkOrderCell.Navigation`.

--- a/packages/dfw/src/dfwcomponents/PropertyRow/PropertyRow.tsx
+++ b/packages/dfw/src/dfwcomponents/PropertyRow/PropertyRow.tsx
@@ -19,6 +19,7 @@ export type PropertyRowProps = {
     iconName?: IconName;
     textColor?: Color;
     selectable?: boolean;
+    wrapValues?: boolean;
 } & ViewProps;
 export const PropertyRow = ({
     label,
@@ -26,6 +27,7 @@ export const PropertyRow = ({
     iconName,
     textColor = "textTertiary",
     selectable,
+    wrapValues,
     ...rest
 }: PropertyRowProps) => {
     const breakpoint = useBreakpoint();
@@ -52,7 +54,7 @@ export const PropertyRow = ({
                     group="paragraph"
                     variant="body_short"
                     color={textColor}
-                    numberOfLines={1}
+                    numberOfLines={wrapValues ? undefined : 1}
                     selectable={selectable}
                 >
                     {value}

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCell.tsx
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCell.tsx
@@ -21,6 +21,7 @@ export const WorkOrderCell = ({
     tecoButton,
     workOrder,
     additionalPropertyRows = [],
+    wrapValues = false,
     ...rest
 }: WorkOrderCellProps) => {
     const breakpoint = useBreakpoint();
@@ -69,6 +70,7 @@ export const WorkOrderCell = ({
                 <WorkOrderPropertyList
                     workOrder={workOrder}
                     additionalPropertyRows={additionalPropertyRows}
+                    wrapValues={wrapValues}
                 />
             </View>
             {shouldShowActions && (

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCellNavigation.tsx
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCellNavigation.tsx
@@ -27,6 +27,7 @@ export const WorkOrderCellNavigation = ({
     leftSwipeGroup,
     rightSwipeGroup,
     additionalPropertyRows = [],
+    wrapValues = false,
     onPress,
     ...rest
 }: WorkOrderCellNavigationProps) => {
@@ -64,7 +65,8 @@ export const WorkOrderCellNavigation = ({
                         <WorkOrderPropertyList
                             workOrder={workOrder}
                             additionalPropertyRows={additionalPropertyRows}
-                        />{" "}
+                            wrapValues={wrapValues}
+                        />
                     </View>
                 </View>
                 {showSymbols && (

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderPropertyList.tsx
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderPropertyList.tsx
@@ -71,11 +71,13 @@ const propertyRowConfig: PropertyRowConfig = [
 type WorkOrderPropertyListProps = {
     workOrder: WorkOrder;
     additionalPropertyRows?: AdditionalPropertyRow[];
+    wrapValues?: boolean;
 };
 
 export const WorkOrderPropertyList = ({
     workOrder,
     additionalPropertyRows = [],
+    wrapValues,
 }: WorkOrderPropertyListProps) => {
     return (
         <>
@@ -91,6 +93,7 @@ export const WorkOrderPropertyList = ({
                         label={label}
                         value={value}
                         textColor={textColor}
+                        wrapValues={wrapValues}
                         selectable
                     />
                 );
@@ -101,6 +104,7 @@ export const WorkOrderPropertyList = ({
                     key={`additional-${index}`}
                     label={item.label}
                     value={item.value}
+                    wrapValues={wrapValues}
                     selectable
                 />
             ))}

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/types.ts
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/types.ts
@@ -67,6 +67,10 @@ export type WorkOrderCellProps = {
      * Additional property rows to be displayed under the work order data
      */
     additionalPropertyRows?: AdditionalPropertyRow[];
+    /**
+     * Boolean value indicating whether or not the values of the work order properties should wrap.
+     */
+    wrapValues?: boolean;
 } & Omit<ViewProps, "children">;
 
 export type StatusConfig = {


### PR DESCRIPTION
New prop, `wrapValues` that make text values wrap in the WorkOrderCell and WorkOrderCell.Navigation.
Aslo found and removed a {" "} in the WorkOrderCell.Navigation that made the app crash on IoS.

Fixes: #648