### PR TITLE
feat(workordercell): add bookmark icons to the navigation variant

### DIFF
--- a/.changeset/spotty-poets-melt.md
+++ b/.changeset/spotty-poets-melt.md
@@ -1,0 +1,6 @@
+---
+"@equinor/mad-dfw": patch
+---
+
+New prop for the `WorkOrderCell.Navigation` called `bookmarked`. Can be used to display the
+`bookmark` and `bookmark-outline` icons.

--- a/.changeset/spotty-poets-melt.md
+++ b/.changeset/spotty-poets-melt.md
@@ -2,5 +2,5 @@
 "@equinor/mad-dfw": patch
 ---
 
-New prop for the `WorkOrderCell.Navigation` called `bookmarked`. Can be used to display the
+New prop for the `WorkOrderCell.Navigation` called `isBookmarked`. Can be used to display the
 `bookmark` and `bookmark-outline` icons.

--- a/apps/chronicles/screens/dfw/dfwcomponents/WorkOrderCellScreen.tsx
+++ b/apps/chronicles/screens/dfw/dfwcomponents/WorkOrderCellScreen.tsx
@@ -1,10 +1,12 @@
-import React from "react";
+import React, { useState } from "react";
 import { EDSStyleSheet, Spacer, Typography, useStyles } from "@equinor/mad-components";
 import { WorkOrderCell } from "@equinor/mad-dfw";
 import { View } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
+import { SwipeableMethods } from "@equinor/mad-components/dist/components/_internal/SwipeableWithContext";
 
 export const WorkOrderCellScreen = () => {
+    const [bookmarked, setBookmarked] = useState(false);
     const styles = useStyles(themeStyles);
 
     return (
@@ -172,6 +174,7 @@ export const WorkOrderCellScreen = () => {
             </View>
             <Spacer />
             <WorkOrderCell.Navigation
+                bookmarked={bookmarked}
                 workOrder={{
                     title: "Work Order Cell",
                     workOrderId: "25282760",
@@ -187,14 +190,24 @@ export const WorkOrderCellScreen = () => {
                 onPress={() => console.log("Pressed")}
                 leftSwipeGroup={[
                     {
-                        title: "Left side here",
-                        color: "success",
+                        title: "Add bookmark",
+                        iconName: "bookmark",
+                        color: "primary",
+                        onPress: (methods: SwipeableMethods) => {
+                            setBookmarked(true);
+                            methods.close();
+                        },
                     },
                 ]}
                 rightSwipeGroup={[
                     {
-                        title: "Right side here",
-                        color: "primary",
+                        title: "Remove bookmark",
+                        iconName: "bookmark-outline",
+                        color: "warning",
+                        onPress: (methods: SwipeableMethods) => {
+                            setBookmarked(false);
+                            methods.close();
+                        },
                     },
                 ]}
             />

--- a/apps/chronicles/screens/dfw/dfwcomponents/WorkOrderCellScreen.tsx
+++ b/apps/chronicles/screens/dfw/dfwcomponents/WorkOrderCellScreen.tsx
@@ -174,7 +174,7 @@ export const WorkOrderCellScreen = () => {
             </View>
             <Spacer />
             <WorkOrderCell.Navigation
-                bookmarked={bookmarked}
+                isBookmarked={bookmarked}
                 workOrder={{
                     title: "Work Order Cell",
                     workOrderId: "25282760",

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCellNavigation.tsx
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCellNavigation.tsx
@@ -19,7 +19,7 @@ type WorkOrderCellNavigationProps = WorkOrderCellProps & {
     onPress: () => void;
     leftSwipeGroup?: SwipeGroup;
     rightSwipeGroup?: SwipeGroup;
-    bookmarked?: boolean;
+    isBookmarked?: boolean;
 };
 
 export const WorkOrderCellNavigation = ({
@@ -29,7 +29,7 @@ export const WorkOrderCellNavigation = ({
     rightSwipeGroup,
     additionalPropertyRows = [],
     wrapValues = false,
-    bookmarked,
+    isBookmarked,
     onPress,
     ...rest
 }: WorkOrderCellNavigationProps) => {
@@ -42,9 +42,9 @@ export const WorkOrderCellNavigation = ({
                 workOrder.requiredEndDate,
                 workOrder.isHseCritical,
                 workOrder.isProductionCritical,
-                bookmarked,
+                isBookmarked,
             ),
-        [bookmarked, workOrder],
+        [isBookmarked, workOrder],
     );
 
     return (

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCellNavigation.tsx
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/WorkOrderCellNavigation.tsx
@@ -19,6 +19,7 @@ type WorkOrderCellNavigationProps = WorkOrderCellProps & {
     onPress: () => void;
     leftSwipeGroup?: SwipeGroup;
     rightSwipeGroup?: SwipeGroup;
+    bookmarked?: boolean;
 };
 
 export const WorkOrderCellNavigation = ({
@@ -28,6 +29,7 @@ export const WorkOrderCellNavigation = ({
     rightSwipeGroup,
     additionalPropertyRows = [],
     wrapValues = false,
+    bookmarked,
     onPress,
     ...rest
 }: WorkOrderCellNavigationProps) => {
@@ -40,8 +42,9 @@ export const WorkOrderCellNavigation = ({
                 workOrder.requiredEndDate,
                 workOrder.isHseCritical,
                 workOrder.isProductionCritical,
+                bookmarked,
             ),
-        [workOrder],
+        [bookmarked, workOrder],
     );
 
     return (

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/utils.ts
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/utils.ts
@@ -1,7 +1,13 @@
 import { StatusConfig } from "./types";
 
-const getStatusIconConfig = (status: string): StatusConfig | undefined => {
+const getStatusIconConfig = (status: string, bookmarked?: boolean): StatusConfig | undefined => {
     const statusMap: Record<string, StatusConfig> = {
+        bookmarked: {
+            icon: bookmarked ? "bookmark" : "bookmark-outline",
+            label: "Bookmarked",
+            textColor: "textTertiary",
+            iconColor: "primary",
+        },
         notStarted: {
             icon: "circle-outline",
             label: "Not started",
@@ -48,6 +54,7 @@ export const getStatusIconsAndLabels = (
     requiredEndDate?: string,
     hseCritical?: boolean,
     productionCritical?: boolean,
+    bookmarked?: boolean,
 ): StatusConfig[] => {
     const today = new Date();
     const iconsAndLabels: StatusConfig[] = [];
@@ -72,6 +79,9 @@ export const getStatusIconsAndLabels = (
         iconsAndLabels.push(getStatusIconConfig("notStarted")!);
     }
 
+    if (bookmarked !== undefined) {
+        iconsAndLabels.push(getStatusIconConfig("bookmarked", bookmarked)!);
+    }
     return iconsAndLabels;
 };
 

--- a/packages/dfw/src/dfwcomponents/WorkOrderCell/utils.ts
+++ b/packages/dfw/src/dfwcomponents/WorkOrderCell/utils.ts
@@ -1,9 +1,9 @@
 import { StatusConfig } from "./types";
 
-const getStatusIconConfig = (status: string, bookmarked?: boolean): StatusConfig | undefined => {
+const getStatusIconConfig = (status: string, isBookmarked?: boolean): StatusConfig | undefined => {
     const statusMap: Record<string, StatusConfig> = {
         bookmarked: {
-            icon: bookmarked ? "bookmark" : "bookmark-outline",
+            icon: isBookmarked ? "bookmark" : "bookmark-outline",
             label: "Bookmarked",
             textColor: "textTertiary",
             iconColor: "primary",
@@ -54,7 +54,7 @@ export const getStatusIconsAndLabels = (
     requiredEndDate?: string,
     hseCritical?: boolean,
     productionCritical?: boolean,
-    bookmarked?: boolean,
+    isBookmarked?: boolean,
 ): StatusConfig[] => {
     const today = new Date();
     const iconsAndLabels: StatusConfig[] = [];
@@ -79,8 +79,8 @@ export const getStatusIconsAndLabels = (
         iconsAndLabels.push(getStatusIconConfig("notStarted")!);
     }
 
-    if (bookmarked !== undefined) {
-        iconsAndLabels.push(getStatusIconConfig("bookmarked", bookmarked)!);
+    if (isBookmarked !== undefined) {
+        iconsAndLabels.push(getStatusIconConfig("bookmarked", isBookmarked)!);
     }
     return iconsAndLabels;
 };


### PR DESCRIPTION
**Key changes:**
- Added a new bookmarked prop to the WorkOrderCell.Navigation component, which can be used to indicate whether the work order is bookmarked or not. Additionally, new icons have been included to reflect the bookmarked state.

Fixes: #653 