### PR TITLE
chore: set max 4 lines of text in toasts

### DIFF
--- a/.changeset/unlucky-phones-smash.md
+++ b/.changeset/unlucky-phones-smash.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-toast": patch
+---
+
+Display max four lines of text in toasts

--- a/packages/toast/src/components/ToastComponent.tsx
+++ b/packages/toast/src/components/ToastComponent.tsx
@@ -28,7 +28,7 @@ export const ToastComponent = ({ text, type, onPress }: ToastComponentProps) => 
         >
             <Paper elevation="raised" style={styles.background}>
                 <Icon name={iconName} color={textColor} />
-                <Typography color={textColor} numberOfLines={2} style={styles.text}>
+                <Typography color={textColor} numberOfLines={4} style={styles.text}>
                     {text}
                 </Typography>
             </Paper>


### PR DESCRIPTION
In some cases we are unable to display the entire toast message using two lines. This PR increases the maximum to 4 lines.