### PR TITLE
feat(button): add loading indicator in the icon button

### DIFF
--- a/.changeset/silly-coats-end.md
+++ b/.changeset/silly-coats-end.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-components": patch
+---
+
+New `busy` prop in the `Button.Icon` component that shows a loading indicator.

--- a/apps/chronicles/screens/components/components/ButtonScreen.tsx
+++ b/apps/chronicles/screens/components/components/ButtonScreen.tsx
@@ -40,6 +40,8 @@ export const ButtonScreen = () => {
                 <Button.Icon name="cloud-outline" color="danger" />
                 <Button.Icon name="fingerprint" color="danger" variant="outlined" />
                 <Button.Icon name="fire" color="danger" variant="ghost" />
+                <Button.Icon name="fish" busy />
+                <Button.Icon name="flask" disabled busy />
             </View>
             <Spacer amount="large" />
 

--- a/packages/components/src/components/Button/IconButton.tsx
+++ b/packages/components/src/components/Button/IconButton.tsx
@@ -61,24 +61,22 @@ export const IconButton = forwardRef<View, IconButtonProps & ViewProps>(
         });
 
         return (
-            <View>
-                <View ref={ref} style={[styles.colorContainer, rest.style]}>
-                    <PressableHighlight
-                        id={rest.id}
-                        disabled={disabled}
-                        onPress={onPress}
-                        style={styles.pressableContainer}
-                    >
-                        {busy ? (
-                            <DotProgress
-                                color={disabled || variant !== "contained" ? "primary" : "neutral"}
-                                size={dotProgressSize}
-                            />
-                        ) : (
-                            <Icon name={name} size={iconSize} color={styles.textStyle.color} />
-                        )}
-                    </PressableHighlight>
-                </View>
+            <View ref={ref} style={[styles.colorContainer, rest.style]}>
+                <PressableHighlight
+                    id={rest.id}
+                    disabled={disabled}
+                    onPress={onPress}
+                    style={styles.pressableContainer}
+                >
+                    {busy ? (
+                        <DotProgress
+                            color={disabled || variant !== "contained" ? "primary" : "neutral"}
+                            size={dotProgressSize}
+                        />
+                    ) : (
+                        <Icon name={name} size={iconSize} color={styles.textStyle.color} />
+                    )}
+                </PressableHighlight>
             </View>
         );
     },

--- a/packages/components/src/components/Button/IconButton.tsx
+++ b/packages/components/src/components/Button/IconButton.tsx
@@ -5,7 +5,7 @@ import { EDSStyleSheet } from "../../styling";
 import { getBackgroundColorForButton } from "../../utils/getBackgroundColorForButton";
 import { Icon, IconName } from "../Icon";
 import { PressableHighlight } from "../PressableHighlight";
-import { DotProgress } from "../ProgressIndicator";
+import { CircularProgress } from "../ProgressIndicator";
 
 export type IconButtonProps = {
     /**
@@ -52,7 +52,6 @@ export const IconButton = forwardRef<View, IconButtonProps & ViewProps>(
         },
         ref,
     ) => {
-        const dotProgressSize = iconSize * 0.3;
         const styles = useStyles(themeStyles, {
             color,
             variant,
@@ -69,9 +68,9 @@ export const IconButton = forwardRef<View, IconButtonProps & ViewProps>(
                     style={styles.pressableContainer}
                 >
                     {busy ? (
-                        <DotProgress
+                        <CircularProgress
                             color={disabled || variant !== "contained" ? "primary" : "neutral"}
-                            size={dotProgressSize}
+                            size={iconSize}
                         />
                     ) : (
                         <Icon name={name} size={iconSize} color={styles.textStyle.color} />

--- a/packages/components/src/components/Button/IconButton.tsx
+++ b/packages/components/src/components/Button/IconButton.tsx
@@ -5,6 +5,7 @@ import { EDSStyleSheet } from "../../styling";
 import { getBackgroundColorForButton } from "../../utils/getBackgroundColorForButton";
 import { Icon, IconName } from "../Icon";
 import { PressableHighlight } from "../PressableHighlight";
+import { DotProgress } from "../ProgressIndicator";
 
 export type IconButtonProps = {
     /**
@@ -16,10 +17,6 @@ export type IconButtonProps = {
      */
     iconSize?: number;
     /**
-     * Callback method invoked when the user presses outside the child content.
-     */
-    onPress?: () => void;
-    /**
      * Color theme of the icon button.
      */
     color?: "primary" | "secondary" | "danger";
@@ -28,9 +25,17 @@ export type IconButtonProps = {
      */
     variant?: "contained" | "outlined" | "ghost";
     /**
+     * Boolean value indicating whether or not the button should be in its busy state.
+     */
+    busy?: boolean;
+    /**
      * Boolean value indicating whether or not the button should be in its disabled state.
      */
     disabled?: boolean;
+    /**
+     * Callback method invoked when the user presses outside the child content.
+     */
+    onPress?: () => void;
 };
 
 export const IconButton = forwardRef<View, IconButtonProps & ViewProps>(
@@ -40,12 +45,14 @@ export const IconButton = forwardRef<View, IconButtonProps & ViewProps>(
             iconSize = 22,
             color = "primary",
             variant = "contained",
-            onPress = () => null,
+            busy = false,
             disabled = false,
+            onPress = () => null,
             ...rest
         },
         ref,
     ) => {
+        const dotProgressSize = iconSize * 0.3;
         const styles = useStyles(themeStyles, {
             color,
             variant,
@@ -62,7 +69,14 @@ export const IconButton = forwardRef<View, IconButtonProps & ViewProps>(
                         onPress={onPress}
                         style={styles.pressableContainer}
                     >
-                        <Icon name={name} size={iconSize} color={styles.textStyle.color} />
+                        {busy ? (
+                            <DotProgress
+                                color={disabled || variant !== "contained" ? "primary" : "neutral"}
+                                size={dotProgressSize}
+                            />
+                        ) : (
+                            <Icon name={name} size={iconSize} color={styles.textStyle.color} />
+                        )}
                     </PressableHighlight>
                 </View>
             </View>


### PR DESCRIPTION
Added new prop, `busy`, in the `Button.Icon` component. When true it shows a loading indicator.

Fixes: #477 