### PR TITLE
docs(3-breakpoints.md): fix typo

### DIFF
--- a/apps/docs/docs/components/getting-started/3-breakpoints.md
+++ b/apps/docs/docs/components/getting-started/3-breakpoints.md
@@ -7,7 +7,7 @@ sidebar_position: 3
 # Breakpoints
 
 Screens come in different sizes, and our component library is made to be viewed on both large and
-small. You might therefore often find yourself having to style or render compoents conditionally
+small. You might therefore often find yourself having to style or render components conditionally
 based on screen size. This is where breakpoints and the `useBreakpoint` hook comes in.
 
 ## Using the `useBreakpoint` hook


### PR DESCRIPTION
Fixing a minor typos in the documentation file `3-breakpoints.md`. 
No functional or code changes.