### PR TITLE
fix: add disabled prop to x icon

### DIFF
--- a/.changeset/dirty-rockets-sin.md
+++ b/.changeset/dirty-rockets-sin.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-components": patch
+---
+
+Add disabled prop to x button in search bar

--- a/packages/components/src/components/Search/Search.tsx
+++ b/packages/components/src/components/Search/Search.tsx
@@ -145,7 +145,7 @@ export const Search = ({
                         </View>
                     }
                     rightAdornments={
-                        text ? (
+                        text && disabled ? (
                             <View style={styles.adornmentIconContainer}>
                                 <Button.Icon
                                     id="search-clear-text-button"
@@ -153,7 +153,6 @@ export const Search = ({
                                     color="primary"
                                     variant="ghost"
                                     onPress={handleClearText}
-                                    disabled={disabled}
                                 />
                             </View>
                         ) : null

--- a/packages/components/src/components/Search/Search.tsx
+++ b/packages/components/src/components/Search/Search.tsx
@@ -153,6 +153,7 @@ export const Search = ({
                                     color="primary"
                                     variant="ghost"
                                     onPress={handleClearText}
+                                    disabled={disabled}
                                 />
                             </View>
                         ) : null

--- a/packages/components/src/components/Search/Search.tsx
+++ b/packages/components/src/components/Search/Search.tsx
@@ -145,7 +145,7 @@ export const Search = ({
                         </View>
                     }
                     rightAdornments={
-                        text && disabled ? (
+                        text && !disabled ? (
                             <View style={styles.adornmentIconContainer}>
                                 <Button.Icon
                                     id="search-clear-text-button"


### PR DESCRIPTION
Add disabled prop to x icon so that it will not let user clear the search field when used