### PR TITLE
fix: make dialog responsive

### DIFF
--- a/.changeset/mighty-readers-film.md
+++ b/.changeset/mighty-readers-film.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-chronicles": patch
+---
+
+Wrap buttons in button screen

--- a/.changeset/sharp-snails-guess.md
+++ b/.changeset/sharp-snails-guess.md
@@ -1,0 +1,10 @@
+---
+"@equinor/mad-components": patch
+---
+
+Make dialog responsive to all text sizes
+
+- Make dialog title responsive
+- Make dialog custom content scrollable
+- Make action buttons wrap when necessary
+- Avoid clipping of button content in dialog action buttons

--- a/apps/chronicles/screens/components/components/ButtonScreen.tsx
+++ b/apps/chronicles/screens/components/components/ButtonScreen.tsx
@@ -102,6 +102,8 @@ const themeStyles = EDSStyleSheet.create(theme => ({
     buttonRow: {
         paddingVertical: 8,
         flexDirection: "row",
+        flexWrap: "wrap",
         justifyContent: "space-around",
+        gap: 12,
     },
 }));

--- a/apps/chronicles/screens/components/components/ButtonScreen.tsx
+++ b/apps/chronicles/screens/components/components/ButtonScreen.tsx
@@ -100,10 +100,10 @@ const themeStyles = EDSStyleSheet.create(theme => ({
         paddingVertical: theme.spacing.container.paddingVertical,
     },
     buttonRow: {
-        paddingVertical: 8,
+        paddingVertical: theme.spacing.container.paddingVertical,
         flexDirection: "row",
         flexWrap: "wrap",
         justifyContent: "space-around",
-        gap: 12,
+        gap: theme.spacing.spacer.small,
     },
 }));

--- a/packages/components/src/components/Button/Button.tsx
+++ b/packages/components/src/components/Button/Button.tsx
@@ -178,9 +178,9 @@ const themeStyles = EDSStyleSheet.create((theme, props: ButtonStyleSheetProps) =
             minHeight: theme.geometry.dimension.button.minHeight - outlinedHeightReduction,
             paddingHorizontal: theme.spacing.button.paddingHorizontal - outlinedPaddingReduction,
             paddingVertical: theme.spacing.button.paddingVertical - outlinedPaddingReduction,
+            justifyContent: "center"
         },
         labelContainer: {
-            flex: 1,
             flexDirection: "row",
             alignItems: "center",
             justifyContent: "center",

--- a/packages/components/src/components/Dialog/Dialog.tsx
+++ b/packages/components/src/components/Dialog/Dialog.tsx
@@ -33,6 +33,7 @@ const themeStyles = EDSStyleSheet.create(
     (theme, props: { style: StyleProp<ViewStyle>; dimensions: ScaledSize }) => ({
         dialog: StyleSheet.flatten({
             backgroundColor: theme.colors.container.elevation.aboveScrim,
+            maxHeight: "100%",
             borderRadius: theme.geometry.border.elementBorderRadius,
             minHeight: theme.geometry.dimension.dialog.minHeight,
             width: theme.geometry.dimension.dialog.defaultWidth,

--- a/packages/components/src/components/Dialog/Dialog.tsx
+++ b/packages/components/src/components/Dialog/Dialog.tsx
@@ -1,11 +1,9 @@
 import React from "react";
 import {
-    ScaledSize,
     StyleProp,
     StyleSheet,
     ViewProps,
     ViewStyle,
-    useWindowDimensions,
 } from "react-native";
 import { EDSStyleSheet } from "../../styling";
 import { useStyles } from "../../hooks/useStyles";
@@ -16,12 +14,11 @@ import { PopInContainer } from "../_internal/PopInContainer";
 type DialogProps = Omit<ScrimProps, "onPress"> & { onScrimPress?: ScrimProps["onPress"] };
 
 export const Dialog = ({ isOpen, onScrimPress, children, ...rest }: DialogProps & ViewProps) => {
-    const dimensions = useWindowDimensions();
-    const styles = useStyles(themeStyles, { style: rest.style, dimensions });
+    const styles = useStyles(themeStyles, { style: rest.style });
     return (
         <Scrim isOpen={isOpen} onPress={onScrimPress}>
             <PopInContainer>
-                <Paper elevation="aboveScrim" style={[styles.dialog, rest.style]} {...rest}>
+                <Paper elevation="aboveScrim" {...rest} style={styles.dialog}>
                     {children}
                 </Paper>
             </PopInContainer>
@@ -30,14 +27,14 @@ export const Dialog = ({ isOpen, onScrimPress, children, ...rest }: DialogProps 
 };
 
 const themeStyles = EDSStyleSheet.create(
-    (theme, props: { style: StyleProp<ViewStyle>; dimensions: ScaledSize }) => ({
-        dialog: StyleSheet.flatten({
+    (theme, props: { style: StyleProp<ViewStyle> }) => ({
+        dialog: StyleSheet.flatten([{
             backgroundColor: theme.colors.container.elevation.aboveScrim,
             maxHeight: "100%",
             borderRadius: theme.geometry.border.elementBorderRadius,
             minHeight: theme.geometry.dimension.dialog.minHeight,
             width: theme.geometry.dimension.dialog.defaultWidth,
-            maxWidth: props.dimensions.width - theme.spacing.container.paddingVertical * 2,
-        }),
+            maxWidth: "100%",
+        }, props.style]),
     }),
 );

--- a/packages/components/src/components/Dialog/DialogActions.tsx
+++ b/packages/components/src/components/Dialog/DialogActions.tsx
@@ -18,6 +18,7 @@ const themeStyles = EDSStyleSheet.create((theme, align: "left" | "right") => ({
     spacer: { flex: 1 },
     actionsContainer: {
         flexDirection: "row",
+        flexWrap: "wrap",
         gap: theme.spacing.dialog.gap,
         justifyContent: align === "left" ? "flex-start" : "flex-end",
         padding: theme.spacing.dialog.padding,

--- a/packages/components/src/components/Dialog/DialogCustomContent.tsx
+++ b/packages/components/src/components/Dialog/DialogCustomContent.tsx
@@ -1,11 +1,17 @@
 import React, { PropsWithChildren } from "react";
-import { View } from "react-native";
+import { Pressable, ScrollView } from "react-native";
 import { EDSStyleSheet } from "../../styling";
 import { useStyles } from "../../hooks/useStyles";
 
 export const DialogCustomContent = ({ children }: PropsWithChildren) => {
     const styles = useStyles(themeStyles);
-    return <View style={styles.customContentContainer}>{children}</View>;
+    return (
+        <ScrollView contentContainerStyle={styles.customContentContainer}>
+            <Pressable>
+                {children}
+            </Pressable>
+        </ScrollView>
+    );
 };
 
 const themeStyles = EDSStyleSheet.create(theme => ({

--- a/packages/components/src/components/Dialog/DialogHeader.tsx
+++ b/packages/components/src/components/Dialog/DialogHeader.tsx
@@ -17,7 +17,7 @@ export const DialogHeader = (props: TextChildren) => {
 
 const themeStyles = EDSStyleSheet.create(theme => ({
     header: {
-        height: theme.geometry.dimension.dialog.header.height - theme.geometry.border.borderWidth,
+        minHeight: theme.geometry.dimension.dialog.header.height - theme.geometry.border.borderWidth,
         width: "100%",
         borderBottomWidth: theme.geometry.border.borderWidth,
         borderBottomColor: theme.colors.border.medium,

--- a/packages/components/src/components/Scrim/Scrim.tsx
+++ b/packages/components/src/components/Scrim/Scrim.tsx
@@ -34,6 +34,8 @@ const themeStyles = EDSStyleSheet.create(theme => ({
     scrim: {
         ...StyleSheet.absoluteFillObject,
         backgroundColor: theme.colors.container.scrim,
+        paddingHorizontal: theme.spacing.container.paddingHorizontal,
+        paddingVertical: theme.spacing.container.paddingVertical
     },
     safeAreaView: {
         flex: 1,

--- a/packages/components/src/components/Scrim/Scrim.tsx
+++ b/packages/components/src/components/Scrim/Scrim.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren } from "react";
-import { LayoutAnimation, Pressable, StyleSheet } from "react-native";
+import { LayoutAnimation, Pressable, SafeAreaView, StyleSheet } from "react-native";
 import { Portal } from "../Portal";
 import { EDSStyleSheet } from "../../styling";
 import { useStyles } from "../../hooks/useStyles";
@@ -22,7 +22,9 @@ export const Scrim = ({ isOpen, onPress, children }: ScrimProps) => {
     return (
         <Portal name="scrim">
             <Pressable style={styles.scrim} onPress={onPress}>
-                {children}
+                <SafeAreaView style={styles.safeAreaView}>
+                    {children}
+                </SafeAreaView>
             </Pressable>
         </Portal>
     );
@@ -31,8 +33,11 @@ export const Scrim = ({ isOpen, onPress, children }: ScrimProps) => {
 const themeStyles = EDSStyleSheet.create(theme => ({
     scrim: {
         ...StyleSheet.absoluteFillObject,
-        justifyContent: "center",
-        alignItems: "center",
         backgroundColor: theme.colors.container.scrim,
     },
+    safeAreaView: {
+        flex: 1,
+        justifyContent: "center",
+        alignItems: "center"
+    }
 }));

--- a/packages/components/src/components/_internal/PopInContainer.tsx
+++ b/packages/components/src/components/_internal/PopInContainer.tsx
@@ -25,10 +25,12 @@ export const PopInContainer = forwardRef<View, PropsWithChildren & ViewProps>(
                 style={[
                     {
                         transform: [{ scale }],
+                        maxHeight: "100%",
+                        maxWidth: "100%"
                     },
                     rest.style,
                 ]}
-            >
+                >
                 {children}
             </Animated.View>
         );


### PR DESCRIPTION
Components
- Make dialog title responsive
- Make dialog custom content scrollable
- Make action buttons wrap when necessary
- Avoid clipping of button content in dialog action buttons

Chronicles
- Wrap buttons in button screen
- Make gap and padding in button row responsive

Closes #711