### PR TITLE
chore: updated changeset to match the mapi spec no 1.39.0

### DIFF
--- a/.changeset/wicked-actors-sin.md
+++ b/.changeset/wicked-actors-sin.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-maintenance-api-ts-wrapper": patch
+---
+
+updated api ts wrapper to mapi api spec 1.39.0


### PR DESCRIPTION
updates changeset to match the mapi spec no 1.39.0