### PR TITLE
fix: Remove duplicate links from about section

### DIFF
--- a/.changeset/quiet-houses-design.md
+++ b/.changeset/quiet-houses-design.md
@@ -1,0 +1,5 @@
+---
+"@equinor/mad-core": minor
+---
+
+removes duplicate link from the about section

--- a/packages/core/src/components/screens/AboutScreen.tsx
+++ b/packages/core/src/components/screens/AboutScreen.tsx
@@ -19,7 +19,9 @@ export const AboutScreen = () => {
     const coreNavigatorType = useCoreNavigatorType();
     const experimentalFeatures = useExperimentalFeatures();
     const authenticationMethod = experimentalFeatures?.useExpoAuthSession ? "Expo" : "MSAL";
-    const endpoints = [getMadCommonBaseUrl(environment)].concat(about?.endpoints ?? []);
+    const endpoints = Array.from(
+        new Set([getMadCommonBaseUrl(environment)].concat(about?.endpoints ?? [])),
+    );
 
     return (
         <ScrollView


### PR DESCRIPTION
Removes duplicate links from about section

![image](https://github.com/user-attachments/assets/170212a8-bd44-468c-a696-03ce475f83a5)
![image](https://github.com/user-attachments/assets/be4dab77-33fd-4353-bfa9-5ceb98a128d1)
